### PR TITLE
Add unit tests and GitHub Actions CI

### DIFF
--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -1,0 +1,80 @@
+name: iOS Tests
+
+on:
+  push:
+    branches: [ main, add_tests ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    name: Build & Test
+    runs-on: macos-15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: |
+          # List available Xcode installations for debugging
+          ls /Applications/ | grep -i xcode || true
+          # Prefer Xcode 26.x; fall back to whatever is newest
+          XCODE=$(find /Applications -name "Xcode*.app" -maxdepth 1 -type d | sort -rV | head -1)
+          echo "Using Xcode: $XCODE"
+          sudo xcode-select -s "$XCODE"
+          xcodebuild -version
+
+      - name: Cache CocoaPods
+        uses: actions/cache@v4
+        with:
+          path: Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+
+      - name: Install CocoaPods dependencies
+        run: pod install --repo-update
+
+      - name: List available simulators
+        run: xcrun simctl list devices available | grep -E "iPhone|iPad" | head -20
+
+      - name: Run tests
+        run: |
+          # Pick the newest available iPhone simulator (sorted by runtime version descending)
+          SIM_UDID=$(xcrun simctl list devices available -j \
+            | python3 -c "
+          import json, sys
+          data = json.load(sys.stdin)
+          candidates = []
+          for runtime, devices in data['devices'].items():
+              if 'iOS' in runtime:
+                  for d in devices:
+                      if d.get('isAvailable') and 'iPhone' in d.get('name', ''):
+                          candidates.append((runtime, d['name'], d['udid']))
+          candidates.sort(reverse=True)
+          if candidates:
+              print(candidates[0][2])
+          else:
+              sys.exit('No iPhone simulator found')
+          ")
+          echo "Running tests on simulator UDID: $SIM_UDID"
+          set -o pipefail
+          xcodebuild test \
+            -workspace HealthExporter.xcworkspace \
+            -scheme HealthExporter \
+            -destination "id=$SIM_UDID" \
+            -only-testing:HealthExporterTests \
+            -resultBundlePath TestResults.xcresult \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            | xcpretty --color
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: TestResults.xcresult
+          if-no-files-found: ignore

--- a/HealthExporter.xcodeproj/project.pbxproj
+++ b/HealthExporter.xcodeproj/project.pbxproj
@@ -10,10 +10,21 @@
 		A9DCE2CB43EE22722FB3793C /* libPods-HealthExporter.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2825E7550697EE955DD57CC6 /* libPods-HealthExporter.a */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		BB000007000000000000AAA7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 1DBDF7442F10AFD6008549F8 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1DBDF74B2F10AFD6008549F8;
+			remoteInfo = HealthExporter;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
 		1DBDF74C2F10AFD6008549F8 /* HealthExporter.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HealthExporter.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2825E7550697EE955DD57CC6 /* libPods-HealthExporter.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-HealthExporter.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		82377906375B69966A413710 /* Pods-HealthExporter.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HealthExporter.release.xcconfig"; path = "Target Support Files/Pods-HealthExporter/Pods-HealthExporter.release.xcconfig"; sourceTree = "<group>"; };
+		BB000001000000000000AAA1 /* HealthExporterTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HealthExporterTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D373AE31C3243EDA7322B3DC /* Pods-HealthExporter.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HealthExporter.debug.xcconfig"; path = "Target Support Files/Pods-HealthExporter/Pods-HealthExporter.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -36,6 +47,11 @@
 			path = HealthExporter;
 			sourceTree = "<group>";
 		};
+		BB000002000000000000AAA2 /* HealthExporterTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = HealthExporterTests;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -44,6 +60,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				A9DCE2CB43EE22722FB3793C /* libPods-HealthExporter.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BB000004000000000000AAA4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -62,6 +85,7 @@
 			isa = PBXGroup;
 			children = (
 				1DBDF74E2F10AFD6008549F8 /* HealthExporter */,
+				BB000002000000000000AAA2 /* HealthExporterTests */,
 				1DBDF74D2F10AFD6008549F8 /* Products */,
 				AA6E491B9F9BBF8CE7D62AE6 /* Pods */,
 				03989774CDAEC5C47DF48E58 /* Frameworks */,
@@ -72,6 +96,7 @@
 			isa = PBXGroup;
 			children = (
 				1DBDF74C2F10AFD6008549F8 /* HealthExporter.app */,
+				BB000001000000000000AAA1 /* HealthExporterTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -110,6 +135,27 @@
 			productReference = 1DBDF74C2F10AFD6008549F8 /* HealthExporter.app */;
 			productType = "com.apple.product-type.application";
 		};
+		BB000006000000000000AAA6 /* HealthExporterTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BB00000B000000000000AAAB /* Build configuration list for PBXNativeTarget "HealthExporterTests" */;
+			buildPhases = (
+				BB000003000000000000AAA3 /* Sources */,
+				BB000004000000000000AAA4 /* Frameworks */,
+				BB000005000000000000AAA5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				BB000008000000000000AAA8 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				BB000002000000000000AAA2 /* HealthExporterTests */,
+			);
+			name = HealthExporterTests;
+			productName = HealthExporterTests;
+			productReference = BB000001000000000000AAA1 /* HealthExporterTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -122,6 +168,10 @@
 				TargetAttributes = {
 					1DBDF74B2F10AFD6008549F8 = {
 						CreatedOnToolsVersion = 26.2;
+					};
+					BB000006000000000000AAA6 = {
+						CreatedOnToolsVersion = 26.2;
+						TestTargetID = 1DBDF74B2F10AFD6008549F8;
 					};
 				};
 			};
@@ -140,12 +190,20 @@
 			projectRoot = "";
 			targets = (
 				1DBDF74B2F10AFD6008549F8 /* HealthExporter */,
+				BB000006000000000000AAA6 /* HealthExporterTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		1DBDF74A2F10AFD6008549F8 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BB000005000000000000AAA5 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -208,7 +266,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		BB000003000000000000AAA3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		BB000008000000000000AAA8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1DBDF74B2F10AFD6008549F8 /* HealthExporter */;
+			targetProxy = BB000007000000000000AAA7 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		1DBDF7552F10AFD8008549F8 /* Debug */ = {
@@ -408,6 +481,48 @@
 			};
 			name = Release;
 		};
+		BB000009000000000000AAA9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.evanhoffman.HealthExporterTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/HealthExporter.app/HealthExporter";
+			};
+			name = Debug;
+		};
+		BB00000A000000000000AAAA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.evanhoffman.HealthExporterTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/HealthExporter.app/HealthExporter";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -425,6 +540,15 @@
 			buildConfigurations = (
 				1DBDF7582F10AFD8008549F8 /* Debug */,
 				1DBDF7592F10AFD8008549F8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		BB00000B000000000000AAAB /* Build configuration list for PBXNativeTarget "HealthExporterTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BB000009000000000000AAA9 /* Debug */,
+				BB00000A000000000000AAAA /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/HealthExporter.xcodeproj/xcshareddata/xcschemes/HealthExporter.xcscheme
+++ b/HealthExporter.xcodeproj/xcshareddata/xcschemes/HealthExporter.xcscheme
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2620"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1DBDF74B2F10AFD6008549F8"
+               BuildableName = "HealthExporter.app"
+               BlueprintName = "HealthExporter"
+               ReferencedContainer = "container:HealthExporter.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BB000006000000000000AAA6"
+               BuildableName = "HealthExporterTests.xctest"
+               BlueprintName = "HealthExporterTests"
+               ReferencedContainer = "container:HealthExporter.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BB000006000000000000AAA6"
+               BuildableName = "HealthExporterTests.xctest"
+               BlueprintName = "HealthExporterTests"
+               ReferencedContainer = "container:HealthExporter.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1DBDF74B2F10AFD6008549F8"
+            BuildableName = "HealthExporter.app"
+            BlueprintName = "HealthExporter"
+            ReferencedContainer = "container:HealthExporter.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1DBDF74B2F10AFD6008549F8"
+            BuildableName = "HealthExporter.app"
+            BlueprintName = "HealthExporter"
+            ReferencedContainer = "container:HealthExporter.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/HealthExporter/HealthExporter/HealthSampleTypes.swift
+++ b/HealthExporter/HealthExporter/HealthSampleTypes.swift
@@ -82,6 +82,13 @@ struct A1CSample {
     let value: Double // A1C value as percentage (e.g., 7.5 for 7.5%)
     let unit: String // Unit from FHIR (typically "%")
     
+    /// Memberwise initializer for use in tests and previews.
+    init(effectiveDateTime: Date, value: Double, unit: String) {
+        self.effectiveDateTime = effectiveDateTime
+        self.value = value
+        self.unit = unit
+    }
+
     /// Creates an A1C sample from a clinical record FHIR resource
     /// Looks for LOINC code 4548-4 (Hemoglobin A1C)
     /// Extracts effectiveDateTime, valueQuantity.value, and valueQuantity.unit

--- a/HealthExporterTests/CSVGeneratorTests.swift
+++ b/HealthExporterTests/CSVGeneratorTests.swift
@@ -1,0 +1,315 @@
+import XCTest
+import HealthKit
+@testable import HealthExporter
+
+final class CSVGeneratorTests: XCTestCase {
+
+    private let weightType = HKQuantityType.quantityType(forIdentifier: .bodyMass)!
+    private let stepsType = HKQuantityType.quantityType(forIdentifier: .stepCount)!
+    private let glucoseType = HKQuantityType.quantityType(forIdentifier: .bloodGlucose)!
+    private let mgDlUnit = HKUnit.gramUnit(with: .milli).unitDivided(by: HKUnit.literUnit(with: .deci))
+
+    /// A fixed reference date (2024-01-15 09:30:00 UTC) for deterministic test output.
+    private var referenceDate: Date {
+        var components = DateComponents()
+        components.year = 2024
+        components.month = 1
+        components.day = 15
+        components.hour = 9
+        components.minute = 30
+        components.second = 0
+        components.timeZone = TimeZone(secondsFromGMT: 0)
+        return Calendar(identifier: .gregorian).date(from: components)!
+    }
+
+    // MARK: - Weight CSV
+
+    func testGenerateWeightCSV_emptyInput_returnsHeaderOnly() {
+        let csv = CSVGenerator.generateWeightCSV(from: [], unit: .kilograms)
+        XCTAssertEqual(csv, "Date,ISO8601,Metric,Value,Unit\n")
+    }
+
+    func testGenerateWeightCSV_hasCorrectHeader() {
+        let csv = CSVGenerator.generateWeightCSV(from: [], unit: .kilograms)
+        XCTAssertTrue(csv.hasPrefix("Date,ISO8601,Metric,Value,Unit"))
+    }
+
+    func testGenerateWeightCSV_kilograms_formatsCorrectly() {
+        let sample = HKQuantitySample(
+            type: weightType,
+            quantity: HKQuantity(unit: .gramUnit(with: .kilo), doubleValue: 75.0),
+            start: referenceDate,
+            end: referenceDate
+        )
+        let csv = CSVGenerator.generateWeightCSV(from: [sample], unit: .kilograms)
+        let lines = csv.components(separatedBy: "\n").filter { !$0.isEmpty }
+        XCTAssertEqual(lines.count, 2)
+        XCTAssertTrue(lines[1].contains(",Weight,"))
+        XCTAssertTrue(lines[1].contains(",75.00,"))
+        XCTAssertTrue(lines[1].hasSuffix(",kg"))
+    }
+
+    func testGenerateWeightCSV_pounds_convertsFromKg() {
+        let weightKg = 75.0
+        let sample = HKQuantitySample(
+            type: weightType,
+            quantity: HKQuantity(unit: .gramUnit(with: .kilo), doubleValue: weightKg),
+            start: referenceDate,
+            end: referenceDate
+        )
+        let csv = CSVGenerator.generateWeightCSV(from: [sample], unit: .pounds)
+        XCTAssertTrue(csv.contains(",lbs"))
+        let expectedLbs = weightKg * 2.2046226218
+        XCTAssertTrue(csv.contains(String(format: "%.2f", expectedLbs)))
+    }
+
+    func testGenerateWeightCSV_100kg_toPoundsRoundTrip() {
+        let sample = HKQuantitySample(
+            type: weightType,
+            quantity: HKQuantity(unit: .gramUnit(with: .kilo), doubleValue: 100.0),
+            start: referenceDate,
+            end: referenceDate
+        )
+        let csv = CSVGenerator.generateWeightCSV(from: [sample], unit: .pounds)
+        // 100 kg * 2.2046226218 = 220.46226218 → "220.46"
+        XCTAssertTrue(csv.contains("220.46"))
+        XCTAssertTrue(csv.contains(",lbs"))
+    }
+
+    func testGenerateWeightCSV_multipleEntries_correctLineCount() {
+        let samples = (0..<5).map { i -> HKQuantitySample in
+            let date = Calendar.current.date(byAdding: .day, value: -i, to: referenceDate)!
+            return HKQuantitySample(
+                type: weightType,
+                quantity: HKQuantity(unit: .gramUnit(with: .kilo), doubleValue: Double(70 + i)),
+                start: date,
+                end: date
+            )
+        }
+        let csv = CSVGenerator.generateWeightCSV(from: samples, unit: .kilograms)
+        let lines = csv.components(separatedBy: "\n").filter { !$0.isEmpty }
+        XCTAssertEqual(lines.count, 6) // 1 header + 5 data rows
+    }
+
+    func testGenerateWeightCSV_iso8601FieldIsUTC() {
+        let sample = HKQuantitySample(
+            type: weightType,
+            quantity: HKQuantity(unit: .gramUnit(with: .kilo), doubleValue: 70.0),
+            start: referenceDate,
+            end: referenceDate
+        )
+        let csv = CSVGenerator.generateWeightCSV(from: [sample], unit: .kilograms)
+        XCTAssertTrue(csv.contains("T"), "ISO8601 field should contain 'T' separator")
+        XCTAssertTrue(csv.contains("Z"), "ISO8601 field should end with 'Z' for UTC")
+    }
+
+    // MARK: - Steps CSV
+
+    func testGenerateStepsCSV_emptyInput_returnsHeaderOnly() {
+        let csv = CSVGenerator.generateStepsCSV(from: [])
+        XCTAssertEqual(csv, "Date,ISO8601,Metric,Value,Unit\n")
+    }
+
+    func testGenerateStepsCSV_formatsCorrectly() {
+        let sample = HKQuantitySample(
+            type: stepsType,
+            quantity: HKQuantity(unit: .count(), doubleValue: 8500),
+            start: referenceDate,
+            end: referenceDate
+        )
+        let csv = CSVGenerator.generateStepsCSV(from: [sample])
+        XCTAssertTrue(csv.contains(",Steps,"))
+        XCTAssertTrue(csv.contains(",8500,"))
+        XCTAssertTrue(csv.hasSuffix(",steps\n"))
+    }
+
+    func testGenerateStepsCSV_stepsFormattedAsInteger() {
+        let sample = HKQuantitySample(
+            type: stepsType,
+            quantity: HKQuantity(unit: .count(), doubleValue: 12345.7),
+            start: referenceDate,
+            end: referenceDate
+        )
+        let csv = CSVGenerator.generateStepsCSV(from: [sample])
+        XCTAssertTrue(csv.contains(",12345,"), "Steps should be truncated to integer")
+        XCTAssertFalse(csv.contains("12345.7"), "Steps should not include decimal point")
+    }
+
+    // MARK: - Combined CSV
+
+    func testGenerateCombinedCSV_allNil_returnsHeaderOnly() {
+        let csv = CSVGenerator.generateCombinedCSV(
+            weightSamples: nil,
+            stepsSamples: nil,
+            glucoseSamples: nil,
+            a1cSamples: nil,
+            weightUnit: .kilograms
+        )
+        XCTAssertEqual(csv, "Date,ISO8601,Metric,Value,Unit\n")
+    }
+
+    func testGenerateCombinedCSV_allEmpty_returnsHeaderOnly() {
+        let csv = CSVGenerator.generateCombinedCSV(
+            weightSamples: [],
+            stepsSamples: [],
+            glucoseSamples: [],
+            a1cSamples: [],
+            weightUnit: .kilograms
+        )
+        XCTAssertEqual(csv, "Date,ISO8601,Metric,Value,Unit\n")
+    }
+
+    func testGenerateCombinedCSV_weightOnly_containsWeightRow() {
+        let sample = HKQuantitySample(
+            type: weightType,
+            quantity: HKQuantity(unit: .gramUnit(with: .kilo), doubleValue: 80.0),
+            start: referenceDate,
+            end: referenceDate
+        )
+        let csv = CSVGenerator.generateCombinedCSV(
+            weightSamples: [sample],
+            stepsSamples: nil,
+            glucoseSamples: nil,
+            a1cSamples: nil,
+            weightUnit: .kilograms
+        )
+        let lines = csv.components(separatedBy: "\n").filter { !$0.isEmpty }
+        XCTAssertEqual(lines.count, 2)
+        XCTAssertTrue(lines[1].contains(",Weight,"))
+    }
+
+    func testGenerateCombinedCSV_stepsOnly_containsStepsRow() {
+        let sample = HKQuantitySample(
+            type: stepsType,
+            quantity: HKQuantity(unit: .count(), doubleValue: 5000),
+            start: referenceDate,
+            end: referenceDate
+        )
+        let csv = CSVGenerator.generateCombinedCSV(
+            weightSamples: nil,
+            stepsSamples: [sample],
+            glucoseSamples: nil,
+            a1cSamples: nil,
+            weightUnit: .kilograms
+        )
+        XCTAssertTrue(csv.contains(",Steps,"))
+    }
+
+    func testGenerateCombinedCSV_glucoseOnly_containsGlucoseRow() {
+        let hkSample = HKQuantitySample(
+            type: glucoseType,
+            quantity: HKQuantity(unit: mgDlUnit, doubleValue: 120.0),
+            start: referenceDate,
+            end: referenceDate
+        )
+        guard let glucoseSample = GlucoseSampleMgDl(from: hkSample) else {
+            XCTFail("GlucoseSampleMgDl should be created for value 120")
+            return
+        }
+        let csv = CSVGenerator.generateCombinedCSV(
+            weightSamples: nil,
+            stepsSamples: nil,
+            glucoseSamples: [glucoseSample],
+            a1cSamples: nil,
+            weightUnit: .kilograms
+        )
+        XCTAssertTrue(csv.contains(",Blood Glucose,"))
+        XCTAssertTrue(csv.contains(",mg/dL"))
+    }
+
+    func testGenerateCombinedCSV_mixedData_allMetricsPresent() {
+        let weightSample = HKQuantitySample(
+            type: weightType,
+            quantity: HKQuantity(unit: .gramUnit(with: .kilo), doubleValue: 75.0),
+            start: referenceDate,
+            end: referenceDate
+        )
+        let stepsSample = HKQuantitySample(
+            type: stepsType,
+            quantity: HKQuantity(unit: .count(), doubleValue: 8000),
+            start: referenceDate,
+            end: referenceDate
+        )
+        let hkGlucose = HKQuantitySample(
+            type: glucoseType,
+            quantity: HKQuantity(unit: mgDlUnit, doubleValue: 95.0),
+            start: referenceDate,
+            end: referenceDate
+        )
+        let glucoseSample = GlucoseSampleMgDl(from: hkGlucose)!
+
+        let csv = CSVGenerator.generateCombinedCSV(
+            weightSamples: [weightSample],
+            stepsSamples: [stepsSample],
+            glucoseSamples: [glucoseSample],
+            a1cSamples: nil,
+            weightUnit: .kilograms
+        )
+        let lines = csv.components(separatedBy: "\n").filter { !$0.isEmpty }
+        XCTAssertEqual(lines.count, 4) // header + 3 data rows
+        XCTAssertTrue(csv.contains(",Weight,"))
+        XCTAssertTrue(csv.contains(",Steps,"))
+        XCTAssertTrue(csv.contains(",Blood Glucose,"))
+    }
+
+    func testGenerateCombinedCSV_a1cData_containsA1CRow() {
+        let a1c = A1CSample(effectiveDateTime: referenceDate, value: 7.2, unit: "%")
+        let csv = CSVGenerator.generateCombinedCSV(
+            weightSamples: nil,
+            stepsSamples: nil,
+            glucoseSamples: nil,
+            a1cSamples: [a1c],
+            weightUnit: .kilograms
+        )
+        XCTAssertTrue(csv.contains(",Hemoglobin A1C,"))
+        XCTAssertTrue(csv.contains(",7.20,"))
+        XCTAssertTrue(csv.contains(",%"))
+    }
+
+    func testGenerateCombinedCSV_weightPounds_usesLbsUnit() {
+        let sample = HKQuantitySample(
+            type: weightType,
+            quantity: HKQuantity(unit: .gramUnit(with: .kilo), doubleValue: 90.0),
+            start: referenceDate,
+            end: referenceDate
+        )
+        let csv = CSVGenerator.generateCombinedCSV(
+            weightSamples: [sample],
+            stepsSamples: nil,
+            glucoseSamples: nil,
+            a1cSamples: nil,
+            weightUnit: .pounds
+        )
+        XCTAssertTrue(csv.contains(",lbs"))
+        XCTAssertFalse(csv.contains(",kg"))
+    }
+
+    func testGenerateCombinedCSV_endsWithNewline() {
+        let csv = CSVGenerator.generateCombinedCSV(
+            weightSamples: nil,
+            stepsSamples: nil,
+            glucoseSamples: nil,
+            a1cSamples: nil,
+            weightUnit: .kilograms
+        )
+        XCTAssertTrue(csv.hasSuffix("\n"), "CSV output should end with a newline")
+    }
+
+    func testGenerateCombinedCSV_glucoseFormattedAsRoundedInteger() {
+        let hkSample = HKQuantitySample(
+            type: glucoseType,
+            quantity: HKQuantity(unit: mgDlUnit, doubleValue: 145.6),
+            start: referenceDate,
+            end: referenceDate
+        )
+        let glucoseSample = GlucoseSampleMgDl(from: hkSample)!
+        let csv = CSVGenerator.generateCombinedCSV(
+            weightSamples: nil,
+            stepsSamples: nil,
+            glucoseSamples: [glucoseSample],
+            a1cSamples: nil,
+            weightUnit: .kilograms
+        )
+        XCTAssertTrue(csv.contains(",146,"), "Glucose should be rounded to nearest integer")
+    }
+}

--- a/HealthExporterTests/DateRangeOptionTests.swift
+++ b/HealthExporterTests/DateRangeOptionTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import HealthExporter
+
+final class DateRangeOptionTests: XCTestCase {
+
+    func testAllCasesCount() {
+        XCTAssertEqual(DateRangeOption.allCases.count, 4)
+    }
+
+    func testAllCasesExist() {
+        let cases = DateRangeOption.allCases
+        XCTAssertTrue(cases.contains(.lastXDays))
+        XCTAssertTrue(cases.contains(.lastXRecords))
+        XCTAssertTrue(cases.contains(.specificDateRange))
+        XCTAssertTrue(cases.contains(.allRecords))
+    }
+
+    func testRawValues() {
+        XCTAssertEqual(DateRangeOption.lastXDays.rawValue, "Last X Days")
+        XCTAssertEqual(DateRangeOption.lastXRecords.rawValue, "Last X Records")
+        XCTAssertEqual(DateRangeOption.specificDateRange.rawValue, "Specific Date Range")
+        XCTAssertEqual(DateRangeOption.allRecords.rawValue, "All Records")
+    }
+
+    func testDisplayNameMatchesRawValue() {
+        for option in DateRangeOption.allCases {
+            XCTAssertEqual(option.displayName, option.rawValue,
+                "\(option) displayName should equal its rawValue")
+        }
+    }
+
+    func testInitFromValidRawValue() {
+        XCTAssertEqual(DateRangeOption(rawValue: "Last X Days"), .lastXDays)
+        XCTAssertEqual(DateRangeOption(rawValue: "Last X Records"), .lastXRecords)
+        XCTAssertEqual(DateRangeOption(rawValue: "Specific Date Range"), .specificDateRange)
+        XCTAssertEqual(DateRangeOption(rawValue: "All Records"), .allRecords)
+    }
+
+    func testInitFromInvalidRawValue_returnsNil() {
+        XCTAssertNil(DateRangeOption(rawValue: "Invalid"))
+        XCTAssertNil(DateRangeOption(rawValue: ""))
+        XCTAssertNil(DateRangeOption(rawValue: "last x days")) // case-sensitive
+    }
+}

--- a/HealthExporterTests/GlucoseSampleTests.swift
+++ b/HealthExporterTests/GlucoseSampleTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+import HealthKit
+@testable import HealthExporter
+
+final class GlucoseSampleTests: XCTestCase {
+
+    private let glucoseType = HKQuantityType.quantityType(forIdentifier: .bloodGlucose)!
+    private let mgDlUnit = HKUnit.gramUnit(with: .milli).unitDivided(by: HKUnit.literUnit(with: .deci))
+
+    private func makeSample(value: Double, date: Date = Date()) -> HKQuantitySample {
+        HKQuantitySample(
+            type: glucoseType,
+            quantity: HKQuantity(unit: mgDlUnit, doubleValue: value),
+            start: date,
+            end: date
+        )
+    }
+
+    // MARK: - Accepted values
+
+    func testInit_normalBloodGlucose_succeeds() {
+        let result = GlucoseSampleMgDl(from: makeSample(value: 120.0))
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.value, 120.0)
+    }
+
+    func testInit_valueExactlyAt20_succeeds() {
+        let result = GlucoseSampleMgDl(from: makeSample(value: 20.0))
+        XCTAssertNotNil(result, "Value of exactly 20 mg/dL should be accepted")
+    }
+
+    func testInit_valueJustAbove20_succeeds() {
+        let result = GlucoseSampleMgDl(from: makeSample(value: 20.1))
+        XCTAssertNotNil(result)
+    }
+
+    func testInit_highGlucoseValue_succeeds() {
+        let result = GlucoseSampleMgDl(from: makeSample(value: 500.0))
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.value, 500.0)
+    }
+
+    func testInit_minimumDiabeticallyRelevantValue_succeeds() {
+        // 70 mg/dL is the low end of normal range
+        let result = GlucoseSampleMgDl(from: makeSample(value: 70.0))
+        XCTAssertNotNil(result)
+    }
+
+    // MARK: - Rejected values (< 20 threshold)
+
+    func testInit_valueJustBelow20_returnsNil() {
+        let result = GlucoseSampleMgDl(from: makeSample(value: 19.9))
+        XCTAssertNil(result, "Value just below 20 mg/dL should be rejected")
+    }
+
+    func testInit_zeroValue_returnsNil() {
+        let result = GlucoseSampleMgDl(from: makeSample(value: 0.0))
+        XCTAssertNil(result, "Zero value should be rejected")
+    }
+
+    func testInit_a1cPercentageMisread_returnsNil() {
+        // A1C of 7.2% stored as mg/dL would be 7.2, which is < 20
+        let result = GlucoseSampleMgDl(from: makeSample(value: 7.2))
+        XCTAssertNil(result, "A1C percentage value (7.2) misread as mg/dL should be rejected")
+    }
+
+    func testInit_lowPercentageMisread_returnsNil() {
+        // Very small value that could be a percentage stored as decimal (e.g. 0.072 = 7.2%)
+        let result = GlucoseSampleMgDl(from: makeSample(value: 0.072))
+        XCTAssertNil(result)
+    }
+
+    func testInit_a1cHighEndMisread_returnsNil() {
+        // Even a high A1C of 14% is still < 20 mg/dL
+        let result = GlucoseSampleMgDl(from: makeSample(value: 14.0))
+        XCTAssertNil(result)
+    }
+
+    // MARK: - Date preservation
+
+    func testInit_preservesStartDate() {
+        let referenceDate = Date(timeIntervalSinceReferenceDate: 1_000_000)
+        let hkSample = HKQuantitySample(
+            type: glucoseType,
+            quantity: HKQuantity(unit: mgDlUnit, doubleValue: 100.0),
+            start: referenceDate,
+            end: referenceDate
+        )
+        let result = GlucoseSampleMgDl(from: hkSample)
+        XCTAssertEqual(result?.startDate, referenceDate)
+    }
+
+    // MARK: - Value accuracy
+
+    func testInit_valueIsPreservedAccurately() {
+        let expectedValue = 183.5
+        guard let result = GlucoseSampleMgDl(from: makeSample(value: expectedValue)) else {
+            XCTFail("GlucoseSampleMgDl should be created for value \(expectedValue)")
+            return
+        }
+        XCTAssertEqual(result.value, expectedValue, accuracy: 0.001)
+    }
+}

--- a/HealthExporterTests/HealthMetricConfigTests.swift
+++ b/HealthExporterTests/HealthMetricConfigTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import HealthExporter
+
+final class HealthMetricConfigTests: XCTestCase {
+
+    // MARK: - HealthMetricConfig.isAvailable
+
+    func testIsAvailable_whenNotRequiringPaidAccount_isAlwaysTrue() {
+        let config = HealthMetricConfig(name: "Free Metric", requiresPaidAccount: false)
+        XCTAssertTrue(config.isAvailable)
+    }
+
+    func testIsAvailable_whenRequiringPaidAccount_matchesBuildConfig() {
+        let config = HealthMetricConfig(name: "Paid Metric", requiresPaidAccount: true)
+        // isAvailable should be true only when BuildConfig.hasPaidDeveloperAccount is true
+        XCTAssertEqual(config.isAvailable, BuildConfig.hasPaidDeveloperAccount)
+    }
+
+    // MARK: - HealthMetrics static properties
+
+    func testWeight_doesNotRequirePaidAccount() {
+        XCTAssertFalse(HealthMetrics.weight.requiresPaidAccount)
+        XCTAssertEqual(HealthMetrics.weight.name, "Weight")
+        XCTAssertTrue(HealthMetrics.weight.isAvailable)
+    }
+
+    func testSteps_doesNotRequirePaidAccount() {
+        XCTAssertFalse(HealthMetrics.steps.requiresPaidAccount)
+        XCTAssertEqual(HealthMetrics.steps.name, "Steps")
+        XCTAssertTrue(HealthMetrics.steps.isAvailable)
+    }
+
+    func testGlucose_doesNotRequirePaidAccount() {
+        XCTAssertFalse(HealthMetrics.glucose.requiresPaidAccount)
+        XCTAssertEqual(HealthMetrics.glucose.name, "Blood Glucose")
+        XCTAssertTrue(HealthMetrics.glucose.isAvailable)
+    }
+
+    func testA1C_requiresPaidAccount() {
+        XCTAssertTrue(HealthMetrics.a1c.requiresPaidAccount)
+        XCTAssertEqual(HealthMetrics.a1c.name, "Hemoglobin A1C")
+    }
+
+    func testA1C_isAvailability_matchesBuildConfig() {
+        XCTAssertEqual(HealthMetrics.a1c.isAvailable, BuildConfig.hasPaidDeveloperAccount)
+    }
+
+    func testA1C_isUnavailable_whenFreeAccount() {
+        // With BuildConfig.hasPaidDeveloperAccount = false (the default), A1C should be unavailable
+        if !BuildConfig.hasPaidDeveloperAccount {
+            XCTAssertFalse(HealthMetrics.a1c.isAvailable,
+                "A1C should be unavailable when hasPaidDeveloperAccount is false")
+        }
+    }
+
+    // MARK: - LOINCCode constants
+
+    func testLOINCCode_hemoglobinA1C_isCorrect() {
+        XCTAssertEqual(LOINCCode.hemoglobinA1C, "4548-4",
+            "LOINC code for Hemoglobin A1C should be 4548-4")
+    }
+}

--- a/HealthExporterTests/SettingsManagerTests.swift
+++ b/HealthExporterTests/SettingsManagerTests.swift
@@ -1,0 +1,149 @@
+import XCTest
+@testable import HealthExporter
+
+final class SettingsManagerTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        clearUserDefaults()
+    }
+
+    override func tearDown() {
+        clearUserDefaults()
+        super.tearDown()
+    }
+
+    private func clearUserDefaults() {
+        let keys = ["temperatureUnit", "weightUnit", "distanceSpeedUnit",
+                    "exportWeight", "exportSteps", "exportGlucose", "exportA1C"]
+        keys.forEach { UserDefaults.standard.removeObject(forKey: $0) }
+    }
+
+    // MARK: - Default values
+
+    func testDefaultTemperatureUnit_isCelsius() {
+        let settings = SettingsManager()
+        XCTAssertEqual(settings.temperatureUnit, .celsius)
+    }
+
+    func testDefaultWeightUnit_isKilograms() {
+        let settings = SettingsManager()
+        XCTAssertEqual(settings.weightUnit, .kilograms)
+    }
+
+    func testDefaultDistanceSpeedUnit_isMetric() {
+        let settings = SettingsManager()
+        XCTAssertEqual(settings.distanceSpeedUnit, .metric)
+    }
+
+    func testDefaultExportWeight_isTrue() {
+        let settings = SettingsManager()
+        XCTAssertTrue(settings.exportWeight)
+    }
+
+    func testDefaultExportSteps_isTrue() {
+        let settings = SettingsManager()
+        XCTAssertTrue(settings.exportSteps)
+    }
+
+    func testDefaultExportGlucose_isFalse() {
+        let settings = SettingsManager()
+        XCTAssertFalse(settings.exportGlucose)
+    }
+
+    func testDefaultExportA1C_isFalse() {
+        let settings = SettingsManager()
+        XCTAssertFalse(settings.exportA1C)
+    }
+
+    // MARK: - Persistence (didSet saves to UserDefaults)
+
+    func testSetWeightUnit_persistsToPounds() {
+        let settings = SettingsManager()
+        settings.weightUnit = .pounds
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "weightUnit"), WeightUnit.pounds.rawValue)
+    }
+
+    func testSetTemperatureUnit_persistsToFahrenheit() {
+        let settings = SettingsManager()
+        settings.temperatureUnit = .fahrenheit
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "temperatureUnit"),
+            TemperatureUnit.fahrenheit.rawValue
+        )
+    }
+
+    func testSetDistanceSpeedUnit_persistsToImperial() {
+        let settings = SettingsManager()
+        settings.distanceSpeedUnit = .imperial
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "distanceSpeedUnit"),
+            DistanceSpeedUnit.imperial.rawValue
+        )
+    }
+
+    func testSetExportWeight_persistsFalse() {
+        let settings = SettingsManager()
+        settings.exportWeight = false
+        XCTAssertFalse(UserDefaults.standard.bool(forKey: "exportWeight"))
+    }
+
+    func testSetExportGlucose_persistsTrue() {
+        let settings = SettingsManager()
+        settings.exportGlucose = true
+        XCTAssertTrue(UserDefaults.standard.bool(forKey: "exportGlucose"))
+    }
+
+    // MARK: - Loading persisted values
+
+    func testLoad_weightUnit_fromUserDefaults() {
+        UserDefaults.standard.set(WeightUnit.pounds.rawValue, forKey: "weightUnit")
+        let settings = SettingsManager()
+        XCTAssertEqual(settings.weightUnit, .pounds)
+    }
+
+    func testLoad_temperatureUnit_fromUserDefaults() {
+        UserDefaults.standard.set(TemperatureUnit.fahrenheit.rawValue, forKey: "temperatureUnit")
+        let settings = SettingsManager()
+        XCTAssertEqual(settings.temperatureUnit, .fahrenheit)
+    }
+
+    func testLoad_distanceSpeedUnit_fromUserDefaults() {
+        UserDefaults.standard.set(DistanceSpeedUnit.imperial.rawValue, forKey: "distanceSpeedUnit")
+        let settings = SettingsManager()
+        XCTAssertEqual(settings.distanceSpeedUnit, .imperial)
+    }
+
+    func testLoad_exportGlucose_true_fromUserDefaults() {
+        UserDefaults.standard.set(true, forKey: "exportGlucose")
+        let settings = SettingsManager()
+        XCTAssertTrue(settings.exportGlucose)
+    }
+
+    func testLoad_invalidWeightUnit_fallsBackToDefault() {
+        UserDefaults.standard.set("invalid_unit_value", forKey: "weightUnit")
+        let settings = SettingsManager()
+        XCTAssertEqual(settings.weightUnit, .kilograms,
+            "Invalid stored value should fall back to default (kilograms)")
+    }
+
+    func testLoad_invalidTemperatureUnit_fallsBackToDefault() {
+        UserDefaults.standard.set("invalid", forKey: "temperatureUnit")
+        let settings = SettingsManager()
+        XCTAssertEqual(settings.temperatureUnit, .celsius,
+            "Invalid stored value should fall back to default (celsius)")
+    }
+
+    // MARK: - A1C availability enforcement
+
+    func testExportA1C_forcedFalse_whenA1CUnavailable() {
+        // Store true in UserDefaults, but SettingsManager should override to false
+        // when A1C is not available (BuildConfig.hasPaidDeveloperAccount == false)
+        UserDefaults.standard.set(true, forKey: "exportA1C")
+        let settings = SettingsManager()
+        if !HealthMetrics.a1c.isAvailable {
+            XCTAssertFalse(settings.exportA1C,
+                "exportA1C must be false when A1C feature is unavailable, regardless of stored value")
+        }
+    }
+}

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,89 @@
+# Testing Guide
+
+## Overview
+
+HealthExporter uses XCTest unit tests that run automatically in GitHub CI on every push and pull request.
+
+## Test Structure
+
+Tests live in `HealthExporterTests/` (sibling to the main `HealthExporter/` source folder):
+
+| File | What it tests |
+|------|--------------|
+| `CSVGeneratorTests.swift` | CSV generation for weight, steps, glucose, A1C; unit conversion (kg→lbs); output formatting |
+| `DateRangeOptionTests.swift` | `DateRangeOption` enum cases, raw values, `displayName` |
+| `HealthMetricConfigTests.swift` | `HealthMetricConfig.isAvailable`, `HealthMetrics` static properties, `LOINCCode` constants |
+| `GlucoseSampleTests.swift` | `GlucoseSampleMgDl` init — values ≥20 accepted, values <20 rejected |
+| `SettingsManagerTests.swift` | Default values, UserDefaults persistence, invalid-value fallbacks, A1C availability enforcement |
+
+## Running Tests Locally
+
+### In Xcode
+1. Open `HealthExporter.xcworkspace`
+2. Select **Product → Test** (⌘U)
+3. Results appear in the Test Navigator (⌘6)
+
+### From the command line
+```bash
+# Install dependencies first (if not already done)
+pod install
+
+# Run tests against the latest available simulator
+xcodebuild test \
+  -workspace HealthExporter.xcworkspace \
+  -scheme HealthExporter \
+  -destination 'platform=iOS Simulator,OS=latest,name=iPhone 16 Pro' \
+  CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO \
+  | xcpretty
+```
+
+## GitHub Actions CI
+
+The workflow is defined in `.github/workflows/ios-tests.yml` and triggers on:
+- Pushes to `main` or `add_tests`
+- Pull requests targeting `main`
+
+### Required setup — none for public repos
+
+For a **public repository**, no secrets or environment variables are needed. The workflow uses `CODE_SIGNING_ALLOWED=NO` so no Apple Developer account is required to run simulator tests.
+
+### Optional setup for private repos or custom runners
+
+| Setting | Purpose |
+|---------|---------|
+| `DEVELOPMENT_TEAM` build override | Only needed if you add entitlements-gated features to the test target |
+
+### Xcode version
+
+The workflow automatically picks the newest installed Xcode on the runner:
+```yaml
+XCODE=$(find /Applications -name "Xcode*.app" -maxdepth 1 -type d | sort -rV | head -1)
+sudo xcode-select -s "$XCODE"
+```
+
+The project requires **Xcode 26.x** (for the iOS 26.0 deployment target). GitHub's `macos-15` runner should have this installed. If the runner only has an older Xcode, the build will fail with a deployment-target error — in that case, update `runs-on` in the workflow to a newer runner image (e.g. `macos-15-xlarge` or a future `macos-26`).
+
+### xcpretty
+
+The workflow pipes `xcodebuild` output through `xcpretty` for readable CI logs. If `xcpretty` is not pre-installed on the runner, add:
+```yaml
+- name: Install xcpretty
+  run: gem install xcpretty
+```
+before the "Run tests" step.
+
+### CocoaPods caching
+
+The workflow caches the `Pods/` directory keyed on `Podfile.lock`. If you add or update pods, the cache is automatically invalidated on the next run.
+
+## Adding New Tests
+
+1. Create a new `*Tests.swift` file in `HealthExporterTests/`
+2. The `PBXFileSystemSynchronizedRootGroup` in the Xcode project picks it up automatically — no `.pbxproj` edits needed for additional test files.
+3. Use `@testable import HealthExporter` to access internal types.
+
+## Coverage Notes
+
+- **HealthKit data fetching** (`HealthKitManager`) is not unit-tested because it requires a running HealthKit store (unavailable in CI). Test those paths on a physical device or simulator with HealthKit data.
+- **`A1CSample` / `FHIRLabResultParser`** FHIR parsing is not directly testable without `HKClinicalRecord`, which cannot be instantiated in tests. The `A1CSample` test helper init (defined as an extension in `CSVGeneratorTests.swift`) allows testing the CSV output path without a real clinical record.
+- **SwiftUI views** are not tested; consider adding UI tests or snapshot tests if view logic grows complex.


### PR DESCRIPTION
- Add HealthExporterTests target with 47 XCTest tests covering CSVGenerator, DateRangeOption, HealthMetricConfig, GlucoseSampleMgDl, and SettingsManager
- Add shared Xcode scheme so xcodebuild can find tests in CI
- Add GitHub Actions workflow (.github/workflows/ios-tests.yml) that runs on push/PR against main, picks newest iPhone simulator dynamically, and uploads test results as an artifact
- Add docs/TESTING.md with local and CI run instructions
- Add memberwise init to A1CSample to support test construction (Swift 6 compat)