### PR TITLE
Add Report a Problem link and issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug Report
+about: Report a problem with HealthExporter
+title: ''
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+A clear description of what the problem is.
+
+**Steps to reproduce**
+1. Go to '...'
+2. Tap on '...'
+3. See error
+
+**Expected behavior**
+What you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain the problem.
+
+**Device info**
+- iPhone model: [e.g., iPhone 15 Pro]
+- iOS version: [e.g., iOS 26.0]
+- App version: [e.g., 1.0]
+
+**Additional context**
+Any other details about the problem.

--- a/HealthExporter/HealthExporter/LaunchView.swift
+++ b/HealthExporter/HealthExporter/LaunchView.swift
@@ -40,6 +40,14 @@ struct LaunchView: View {
                             .cornerRadius(10)
                     }
 
+                }
+                .transition(.opacity)
+            }
+
+            Spacer()
+
+            if !isLaunching {
+                VStack(spacing: 12) {
                     Button(action: {
                         showingSettings = true
                     }) {
@@ -50,11 +58,18 @@ struct LaunchView: View {
                         .font(.body)
                         .foregroundColor(.blue)
                     }
+
+                    Link(destination: URL(string: "https://github.com/evandhoffman/HealthExporter/issues/new?template=bug_report.md")!) {
+                        HStack(spacing: 6) {
+                            Image(systemName: "exclamationmark.bubble")
+                            Text("Report a Problem")
+                        }
+                        .font(.body)
+                        .foregroundColor(.blue)
+                    }
                 }
                 .transition(.opacity)
             }
-
-            Spacer()
 
             Text("\u{00A9} \(String(Calendar.current.component(.year, from: Date()))) Evan Hoffman")
                 .font(.footnote)


### PR DESCRIPTION
## Summary
- Moves Settings button to bottom of launch screen (below the Spacer)
- Adds a "Report a Problem" link that opens the GitHub issue creation page with the bug report template
- Adds `.github/ISSUE_TEMPLATE/bug_report.md` with fields for description, steps to reproduce, expected behavior, screenshots, and device info
- Both Settings and Report a Problem only appear after splash loading completes

## Test plan
- [ ] Launch app — verify Settings and "Report a Problem" appear at the bottom after splash loads
- [ ] Tap "Report a Problem" — verify it opens Safari/GitHub to the new issue page with the bug report template
- [ ] Tap "Settings" — verify settings sheet still works
- [ ] Create a test issue on GitHub — verify the template fields render correctly

Closes #21