### PR TITLE
Set bundle display name to HealthExporterCSV

### DIFF
--- a/HealthExporter.xcodeproj/project.pbxproj
+++ b/HealthExporter.xcodeproj/project.pbxproj
@@ -354,6 +354,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = HealthExporter/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = HealthExporterCSV;
 				INFOPLIST_KEY_NSHealthClinicalHealthRecordsShareUsageDescription = "HealthExporter needs access to your clinical health records to export your Hemoglobin A1C results.";
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "HealthExporter needs access to your health data to export your weight, steps, and glucose measurements.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -390,6 +391,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = HealthExporter/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = HealthExporterCSV;
 				INFOPLIST_KEY_NSHealthClinicalHealthRecordsShareUsageDescription = "HealthExporter needs access to your clinical health records to export your Hemoglobin A1C results.";
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "HealthExporter needs access to your health data to export your weight, steps, and glucose measurements.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;


### PR DESCRIPTION
## Summary
- Adds `INFOPLIST_KEY_CFBundleDisplayName = HealthExporterCSV` to both Debug and Release build settings
- Ensures the name under the app icon on the home screen matches the App Store Connect listing

## Notes
- The bundle identifier (`com.evanhoffman.HealthExporter`) is unchanged
- Internal references (logger subsystem, CSV filename prefix) remain as-is — only the user-facing display name changes