### PR TITLE
Add GitHub Pages site for privacy policy

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,2 @@
+title: HealthExporterCSV
+theme: minima

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,8 @@
+---
+layout: home
+title: HealthExporterCSV
+---
+
+Easily export Apple Health data to CSV. Choose your metrics, pick a date range, and save. Private by design — no data ever leaves your device.
+
+- [Privacy Policy](/HealthExporter/privacy-policy/)

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,3 +1,9 @@
+---
+layout: page
+title: Privacy Policy
+permalink: /privacy-policy/
+---
+
 # Privacy Policy — HealthExporterCSV
 
 **Last updated:** March 2026


### PR DESCRIPTION
## Summary
- Adds Jekyll config (`docs/_config.yml`) and index page (`docs/index.md`)
- Adds front matter to `docs/privacy-policy.md` so it renders as a proper page
- After merging, enable GitHub Pages in **Settings > Pages > Source: Deploy from a branch > Branch: main, folder: /docs**

Privacy policy URL for App Store Connect:
`https://evandhoffman.github.io/HealthExporter/privacy-policy/`