### PR TITLE
Only prompt for Health Records when A1C is selected

### DIFF
--- a/HealthExporter/HealthExporter/DataSelectionView.swift
+++ b/HealthExporter/HealthExporter/DataSelectionView.swift
@@ -82,7 +82,11 @@ struct DataSelectionView: View {
             HStack {
                 HStack(spacing: 4) {
                     Text("Hemoglobin A1C (%)")
-                    if !HealthMetrics.a1c.isAvailable {
+                    if HealthMetrics.a1c.isAvailable {
+                        Image(systemName: "cross.case")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    } else {
                         Text("💰")
                             .font(.caption)
                     }
@@ -103,7 +107,20 @@ struct DataSelectionView: View {
             .padding(.horizontal)
             .opacity(HealthMetrics.a1c.isAvailable ? 1.0 : 0.5)
             .disabled(!HealthMetrics.a1c.isAvailable)
-            
+
+            if HealthMetrics.a1c.isAvailable {
+                HStack(spacing: 4) {
+                    Image(systemName: "cross.case")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                    Text("Requires access to Clinical Health Records")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+                .padding(.horizontal)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
             Divider()
                 .padding()
             
@@ -249,7 +266,7 @@ struct DataSelectionView: View {
     }
     
     private func exportData() {
-        healthManager.requestAuthorization { success, error in
+        healthManager.requestAuthorization(includeA1C: settings.exportA1C) { success, error in
             guard success else {
                 DispatchQueue.main.async {
                     logger.error("Authorization failed: \(error?.localizedDescription ?? "Unknown error")")

--- a/HealthExporter/HealthExporter/HealthKitManager.swift
+++ b/HealthExporter/HealthExporter/HealthKitManager.swift
@@ -5,20 +5,20 @@ class HealthKitManager {
     let healthStore = HKHealthStore()
     private static let logger = Logger(subsystem: "com.HealthExporter", category: "HealthKit")
     
-    func requestAuthorization(completion: @escaping (Bool, Error?) -> Void) {
+    func requestAuthorization(includeA1C: Bool = false, completion: @escaping (Bool, Error?) -> Void) {
         guard HKHealthStore.isHealthDataAvailable() else {
             completion(false, NSError(domain: "HealthKit", code: 1, userInfo: [NSLocalizedDescriptionKey: "HealthKit is not available"]))
             return
         }
-        
+
         let weightType = HKQuantityType.quantityType(forIdentifier: .bodyMass)!
         let stepsType = HKQuantityType.quantityType(forIdentifier: .stepCount)!
         let glucoseType = HKQuantityType.quantityType(forIdentifier: .bloodGlucose)!
-        
+
         var typesToRead: Set<HKObjectType> = [weightType, stepsType, glucoseType]
 
-        // Add Clinical Records for A1C if the paid account entitlement is available
-        if HealthMetrics.a1c.isAvailable,
+        // Only request Clinical Records access when A1C is actually selected
+        if includeA1C, HealthMetrics.a1c.isAvailable,
            let clinicalType = HKObjectType.clinicalType(forIdentifier: .labResultRecord) {
             typesToRead.insert(clinicalType)
         }


### PR DESCRIPTION
## Summary
- Only request Clinical Health Records authorization when A1C is actually selected for export (previously requested it whenever `hasPaidDeveloperAccount` was true)
- Added `includeA1C` parameter to `HealthKitManager.requestAuthorization()` 
- Added visual indicator (medical cross icon) and footnote on A1C metric explaining it requires Clinical Health Records access

## Test plan
- [ ] Toggle only Weight/Steps/Glucose and export — should NOT see "Share Health Records" prompt
- [ ] Toggle A1C on and export — should see "Share Health Records" prompt
- [ ] Verify footnote appears below A1C toggle

Fixes #35