### PR TITLE
Update documentation for v2.2.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-HealthExporter is an iOS app built with SwiftUI that exports HealthKit data to CSV files. The app allows users to export their weight and steps history with optional date range filtering and configurable unit preferences.
+HealthExporter is an iOS app built with SwiftUI that exports HealthKit data (Weight, Steps, Blood Glucose, Hemoglobin A1C) to CSV files. The app supports configurable date formats, sort order, unit preferences, and flexible date range filtering.
 
 ## Tech Stack
 
@@ -19,29 +19,34 @@ HealthExporter/
 ├── HealthExporter/
 │   └── HealthExporter/           # Main source folder
 │       ├── HealthExporterApp.swift   # App entry point (@main)
-│       ├── SplashView.swift          # Welcome/splash screen with settings access
+│       ├── LaunchView.swift          # Splash screen with spinner + settings access
 │       ├── DataSelectionView.swift   # Data selection, date range & export UI
-│       ├── SettingsView.swift        # Settings panel for unit preferences
+│       ├── SettingsView.swift        # Settings: export format, units, test data
 │       ├── SettingsManager.swift     # Settings persistence with UserDefaults
 │       ├── HealthKitManager.swift    # HealthKit authorization & queries
 │       ├── HealthMetricConfig.swift  # Metric configuration with availability rules
-│       ├── CSVGenerator.swift        # CSV string generation with unit conversion
+│       ├── HealthSampleTypes.swift   # Glucose, A1C, FHIR parsing
+│       ├── CSVGenerator.swift        # CSV generation with unit conversion, date format, sort order
 │       ├── CSVDocument.swift         # FileDocument for SwiftUI fileExporter
-│       ├── ShareSheet.swift          # UIActivityViewController wrapper
+│       ├── BuildConfig.swift         # Feature flags (paid account gating)
+│       ├── DateRangeOption.swift     # Date range selection enum
+│       ├── ExportError.swift         # Localized error types
+│       ├── PrivacyPolicyView.swift   # Privacy policy & disclaimer view
 │       └── Assets.xcassets/          # App assets
+├── HealthExporterTests/          # Unit tests
 └── README.md
 ```
 
 ## Architecture
 
 ### Views
-- **SplashView**: Welcome screen with "Next" button and gear icon for Settings
+- **LaunchView**: Welcome/splash screen with "Next" button and gear icon for Settings
 - **DataSelectionView**: Main screen with metric toggles (Weight, Steps, Blood Glucose, A1C), date pickers, and Save/Share buttons
-- **SettingsView**: Unit preference configuration (Temperature, Weight, Distance/Speed)
+- **SettingsView**: Export format (date format, sort order) and unit preference configuration (Temperature, Weight, Distance/Speed)
 
 ### Managers
 - **HealthKitManager**: Handles HealthKit authorization and data fetching with optional date range filtering
-- **SettingsManager**: ObservableObject that persists unit preferences via UserDefaults
+- **SettingsManager**: ObservableObject that persists unit preferences, date format, and sort order via UserDefaults
 - **HealthMetricConfig**: Defines metric metadata including `requiresPaidAccount` flag and availability checks
 
 ### Utilities
@@ -82,17 +87,24 @@ HealthExporter/
 
 ## CSV Output Format
 
-Columns: `Date, ISO8601, Metric, Value, Unit`
+Columns: `Date, Metric, Value, Unit, Source`
 
-Formatting:
-- **Date**: `yyyy-MM-dd HH:mm:ss`
-- **ISO8601**: `yyyy-MM-dd'T'HH:mm:ssZ` (UTC/Zulu)
+Date format is user-selectable in Settings via `DateFormatOption`:
+- `yyyy-MM-dd HH:mm:ss` (default, local time)
+- ISO8601 (UTC)
+- `yyyy/MM/dd HH:mm:ss`
+- `MM/dd/yyyy HH:mm:ss`
+- `dd MMM yyyy HH:mm:ss`
+
+Sort order is configurable: ascending (oldest first, default) or descending (newest first).
 
 Example:
 ```
-Date,ISO8601,Metric,Value,Unit
-2026-01-09 10:30:00,2026-01-09T10:30:00Z,Weight,185.50,lbs
-2026-01-09 11:00:00,2026-01-09T11:00:00Z,Steps,5432,steps
+Date,Metric,Value,Unit,Source
+2026-01-09 10:30:00,Weight,185.50,lbs,Withings
+2026-01-09 11:00:00,Steps,5432,steps,Apple Watch
+2026-01-09 14:30:00,Blood Glucose,145,mg/dL,MyFitnessPal
+2026-01-15 14:30:00,Hemoglobin A1C,7.50,%,Apple Health
 ```
 
 Filename format: `HealthExporter_YYYY-MM-DD_HHMMSS.csv`
@@ -107,7 +119,7 @@ Filename format: `HealthExporter_YYYY-MM-DD_HHMMSS.csv`
 
 ### Testing Status
 
-- Hemoglobin A1C export is currently untested end-to-end because there is no paid Apple Developer account available to enable Clinical Health Records during development. Treat A1C functionality as experimental until verified on-device with the capability enabled.
+- Hemoglobin A1C export has been verified working end-to-end on a physical device with Clinical Health Records enabled. The feature is gated behind `BuildConfig.hasPaidDeveloperAccount`.
 
 ### Metric Availability Pattern
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,8 +32,8 @@ xcodebuild -project HealthExporter.xcodeproj -scheme HealthExporter -configurati
 |------|------|
 | `HealthKitManager.swift` | HealthKit authorization + data fetching; uses DispatchGroup for parallel concurrent queries |
 | `HealthMetricConfig.swift` | Central metric registry with `requiresPaidAccount` flags and `isAvailable` checks |
-| `SettingsManager.swift` | `@ObservableObject` persisting unit prefs to UserDefaults; forces unavailable metrics to `false` at init |
-| `CSVGenerator.swift` | Converts HKQuantitySample arrays → CSV string with unit conversion |
+| `SettingsManager.swift` | `@ObservableObject` persisting unit/format prefs to UserDefaults; forces unavailable metrics to `false` at init |
+| `CSVGenerator.swift` | Converts HKQuantitySample arrays → CSV string with unit conversion, configurable date format and sort order |
 | `BuildConfig.swift` | Feature flag: `hasPaidDeveloperAccount` gates A1C availability |
 | `DataSelectionView.swift` | Main UI: metric toggles, date range picker, Save/Share export buttons |
 
@@ -95,8 +95,10 @@ Date,Metric,Value,Unit,Source
   - `yyyy/MM/dd HH:mm:ss`
   - `MM/dd/yyyy HH:mm:ss`
   - `dd MMM yyyy HH:mm:ss`
+- **Sort Order**: Configurable via `SortOrder` enum — ascending (oldest first, default) or descending (newest first)
 - Filename: `HealthExporter_YYYY-MM-DD_HHMMSS.csv`
 - Weight precision: 2 decimal places
+- Default units: Fahrenheit, lbs, imperial (US customary)
 
 ## Required Capabilities
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ A privacy-focused iOS app that exports Apple HealthKit data to CSV files. All da
 - **Privacy-first design**: All processing on-device, no analytics, no tracking, no accounts
 - **Multiple health metrics**: Export Weight, Steps, Blood Glucose (mg/dL), and Hemoglobin A1C (%)
 - **Flexible date ranges**: Last X days, last X records, custom date range, or all data
-- **Unit preferences**: Configure weight units (kg/lbs), temperature (°C/°F), and distance/speed (metric/imperial)
+- **Unit preferences**: Configure weight units (kg/lbs), temperature (°C/°F), and distance/speed (metric/imperial); defaults to US units (Fahrenheit, lbs, imperial)
+- **Selectable date format**: Choose from 5 date formats including ISO8601 (UTC), `yyyy-MM-dd HH:mm:ss`, `MM/dd/yyyy HH:mm:ss`, and more
+- **Sort order**: Export rows in ascending (oldest first) or descending (newest first) order
 - **Dual export options**:
   - **Save**: Save directly to Files app via `.fileExporter()`
   - **Share**: Share via iOS share sheet (Dropbox, Google Drive, email, etc.)
@@ -37,7 +39,7 @@ A privacy-focused iOS app that exports Apple HealthKit data to CSV files. All da
 
 ## Setup
 
-1. Open `HealthExporter.xcworkspace` in Xcode
+1. Open `HealthExporter.xcodeproj` in Xcode
 2. Ensure HealthKit is enabled in Signing & Capabilities
 3. If using Hemoglobin A1C export with a paid Apple Developer account, enable **Clinical Health Records** capability (see [A1C docs](docs/a1c/) for details)
 4. Build and run on a physical device (HealthKit has limited simulator support)
@@ -57,23 +59,32 @@ The exported CSV includes the following columns:
 
 | Column | Description |
 |--------|-------------|
-| **Date** | Timestamp in Excel-friendly format (`yyyy-MM-dd HH:mm:ss`, local time) |
-| **ISO8601** | Timestamp in ISO8601 format (`yyyy-MM-dd'T'HH:mm:ssZ`, UTC) |
+| **Date** | Timestamp in user-selected format (see below) |
 | **Metric** | Type of measurement (Weight, Steps, Blood Glucose, Hemoglobin A1C) |
 | **Value** | Numeric value (weight/A1C: 2 decimal places; glucose: integer; steps: integer) |
 | **Unit** | Unit of measurement (kg, lbs, steps, mg/dL, %) |
 | **Source** | The app or device that recorded the data (e.g., Withings, Apple Watch) |
 
+### Date Format Options
+
+| Format | Example |
+|--------|---------|
+| `yyyy-MM-dd HH:mm:ss` (default) | 2026-01-09 10:30:00 |
+| ISO8601 (UTC) | 2026-01-09T10:30:00Z |
+| `yyyy/MM/dd HH:mm:ss` | 2026/01/09 10:30:00 |
+| `MM/dd/yyyy HH:mm:ss` | 01/09/2026 10:30:00 |
+| `dd MMM yyyy HH:mm:ss` | 09 Jan 2026 10:30:00 |
+
 Example:
 ```
-Date,ISO8601,Metric,Value,Unit,Source
-2026-01-09 10:30:00,2026-01-09T10:30:00Z,Weight,185.50,lbs,Withings
-2026-01-09 11:00:00,2026-01-09T11:00:00Z,Steps,5432,steps,Apple Watch
-2026-01-09 14:30:00,2026-01-09T14:30:00Z,Blood Glucose,145,mg/dL,MyFitnessPal
-2026-01-15 14:30:00,2026-01-15T14:30:00Z,Hemoglobin A1C,7.50,%,Apple Health
+Date,Metric,Value,Unit,Source
+2026-01-09 10:30:00,Weight,185.50,lbs,Withings
+2026-01-09 11:00:00,Steps,5432,steps,Apple Watch
+2026-01-09 14:30:00,Blood Glucose,145,mg/dL,MyFitnessPal
+2026-01-15 14:30:00,Hemoglobin A1C,7.50,%,Apple Health
 ```
 
-Data is sorted chronologically within each metric type. Filename format: `HealthExporter_YYYY-MM-DD_HHMMSS.csv`.
+Data can be sorted ascending (oldest first) or descending (newest first) within each metric type. Filename format: `HealthExporter_YYYY-MM-DD_HHMMSS.csv`.
 
 ## Requirements
 
@@ -95,7 +106,7 @@ Unit tests run automatically in GitHub Actions CI on every push and PR. See [doc
 
 ### A1C Testing Status
 
-Hemoglobin A1C export is currently **untested end-to-end**. The code compiles and is gated behind availability checks, but Clinical Health Records requires a paid Apple Developer account and a physical device with synced clinical records. See [docs/a1c/](docs/a1c/) for implementation details.
+Hemoglobin A1C export has been **verified working end-to-end** on a physical device with Clinical Health Records enabled. The feature is gated behind `BuildConfig.hasPaidDeveloperAccount`. See [docs/a1c/](docs/a1c/) for implementation details.
 
 ## Project Structure
 
@@ -107,17 +118,15 @@ HealthExporter/
 │   ├── Info.plist
 │   └── HealthExporter/
 │       ├── HealthExporterApp.swift      # App entry point, NavigationStack
-│       ├── LaunchView.swift             # Splash screen with spinner
-│       ├── SplashView.swift             # Main menu with settings access
+│       ├── LaunchView.swift             # Splash screen with spinner + settings access
 │       ├── DataSelectionView.swift      # Metric selection & export UI
-│       ├── SettingsView.swift           # Unit preferences & test data
+│       ├── SettingsView.swift           # Unit/format preferences & test data
 │       ├── PrivacyPolicyView.swift      # Privacy policy & disclaimer
 │       ├── HealthKitManager.swift       # HealthKit auth & data fetching
 │       ├── HealthMetricConfig.swift     # Central metric registry
 │       ├── HealthSampleTypes.swift      # Glucose, A1C, FHIR parsing
 │       ├── CSVGenerator.swift           # CSV generation & unit conversion
 │       ├── CSVDocument.swift            # FileDocument for saving
-│       ├── ShareSheet.swift             # UIActivityViewController wrapper
 │       ├── SettingsManager.swift        # UserDefaults persistence
 │       ├── DateRangeOption.swift        # Date range selection enum
 │       ├── ExportError.swift            # Localized error types
@@ -167,7 +176,7 @@ Your health data is used solely to generate CSV export files on your device. Spe
 
 ### Data Storage
 
-The only data HealthExporter stores persistently is your unit preferences (e.g., lbs vs. kg) in the app's local UserDefaults. No health data, personal identifiers, or usage analytics are stored.
+The only data HealthExporter stores persistently is your preferences (unit selections, date format, sort order) in the app's local UserDefaults. No health data, personal identifiers, or usage analytics are stored.
 
 ### No Data Collection or Transmission
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -17,20 +17,17 @@ Tests live in `HealthExporterTests/` (sibling to the main `HealthExporter/` sour
 ## Running Tests Locally
 
 ### In Xcode
-1. Open `HealthExporter.xcworkspace`
+1. Open `HealthExporter.xcodeproj`
 2. Select **Product → Test** (⌘U)
 3. Results appear in the Test Navigator (⌘6)
 
 ### From the command line
 ```bash
-# Install dependencies first (if not already done)
-pod install
-
 # Run tests against the latest available simulator
 xcodebuild test \
-  -workspace HealthExporter.xcworkspace \
+  -project HealthExporter.xcodeproj \
   -scheme HealthExporter \
-  -destination 'platform=iOS Simulator,OS=latest,name=iPhone 16 Pro' \
+  -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' \
   CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO \
   | xcpretty
 ```
@@ -69,10 +66,6 @@ The workflow pipes `xcodebuild` output through `xcpretty` for readable CI logs. 
   run: gem install xcpretty
 ```
 before the "Run tests" step.
-
-### CocoaPods caching
-
-The workflow caches the `Pods/` directory keyed on `Podfile.lock`. If you add or update pods, the cache is automatically invalidated on the next run.
 
 ## Adding New Tests
 

--- a/docs/a1c/IMPLEMENTATION_GUIDE.md
+++ b/docs/a1c/IMPLEMENTATION_GUIDE.md
@@ -3,7 +3,7 @@
 ## Overview
 Hemoglobin A1C export capability has been successfully added to HealthExporter. This feature allows users to export their A1C lab results from HealthKit's Clinical Records.
 
-> Testing status: This A1C functionality is currently untested end-to-end because there is no paid Apple Developer account available to enable Clinical Health Records during development. The implementation is present and behind capability checks, but it has not been validated on-device.
+> Testing status: A1C export has been verified working end-to-end on a physical device with Clinical Health Records enabled.
 
 ## Implementation Details
 
@@ -51,7 +51,7 @@ func fetchA1CData(dateRange: (startDate: Date, endDate: Date)? = nil,
   - Metric name: "Hemoglobin A1C"
   - Value formatted to 2 decimal places
   - Unit: From FHIR resource (typically "%")
-  - Example row: `2026-01-15 14:30:00,2026-01-15T14:30:00Z,Hemoglobin A1C,7.50,%,Apple Health`
+  - Example row: `2026-01-15 14:30:00,Hemoglobin A1C,7.50,%,Apple Health`
 
 ## Required Configuration
 
@@ -126,11 +126,11 @@ The implementation includes comprehensive error handling:
 ## CSV Output Example
 
 ```csv
-Date,ISO8601,Metric,Value,Unit,Source
-2026-01-15 14:30:00,2026-01-15T14:30:00Z,Weight,185.50,lbs,Withings
-2026-01-15 14:30:00,2026-01-15T14:30:00Z,Steps,5432,steps,Apple Watch
-2026-01-15 14:30:00,2026-01-15T14:30:00Z,Blood Glucose,145,mg/dL,MyFitnessPal
-2026-01-15 14:30:00,2026-01-15T14:30:00Z,Hemoglobin A1C,7.50,%,Apple Health
+Date,Metric,Value,Unit,Source
+2026-01-15 14:30:00,Weight,185.50,lbs,Withings
+2026-01-15 14:30:00,Steps,5432,steps,Apple Watch
+2026-01-15 14:30:00,Blood Glucose,145,mg/dL,MyFitnessPal
+2026-01-15 14:30:00,Hemoglobin A1C,7.50,%,Apple Health
 ```
 
 ## Integration with Existing Flow

--- a/docs/a1c/QUICK_REFERENCE.md
+++ b/docs/a1c/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # ✅ Hemoglobin A1C Implementation - Quick Reference
 
-> Testing status: A1C export is currently untested end-to-end because there is no paid Apple Developer account available to enable Clinical Health Records during development. The code compiles but has not been verified on-device.
+> Testing status: A1C export has been verified working end-to-end on a physical device with Clinical Health Records enabled.
 
 ## What Was Added
 
@@ -31,7 +31,7 @@
 ### CSV Export
 - **File**: `CSVGenerator.swift`
 - **Updated**: `generateCombinedCSV()` method
-- A1C data formatted as: `Date,ISO8601,Hemoglobin A1C,Value,%`
+- A1C data formatted as: `Date,Hemoglobin A1C,Value,%,Source`
 
 ---
 
@@ -90,8 +90,8 @@ Add this key (adjust description as needed):
 
 4. **CSV Example**
    ```
-   Date,ISO8601,Metric,Value,Unit,Source
-   2026-01-15 14:30:00,2026-01-15T14:30:00Z,Hemoglobin A1C,7.50,%,Apple Health
+   Date,Metric,Value,Unit,Source
+   2026-01-15 14:30:00,Hemoglobin A1C,7.50,%,Apple Health
    ```
 
 ---
@@ -110,7 +110,7 @@ Add this key (adjust description as needed):
 ### CSV Generation
 - Seamlessly appended to existing combined CSV format
 - Follows same formatting pattern as other metrics
-- Maintains ISO8601 timestamps
+- Supports user-selectable date format and sort order
 
 ### Settings Storage
 - Uses UserDefaults like other metrics

--- a/docs/app-store-review.md
+++ b/docs/app-store-review.md
@@ -3,7 +3,7 @@
 **Date:** 2026-03-01
 **Bundle ID:** `com.evanhoffman.HealthExporter`
 **Platform:** iOS 26+, iPhone & iPad
-**Version:** 1.0 (Build 1)
+**Version:** 2.2.0
 
 ---
 


### PR DESCRIPTION
## Summary
- Updated CSV format documentation from dual Date/ISO8601 columns to single Date column with selectable format
- Documented new v2.2.0 features: 5 date format options, ascending/descending sort order, US default units
- Marked A1C export as verified working end-to-end (previously listed as untested)
- Fixed stale references: `xcworkspace` → `xcodeproj`, removed CocoaPods mentions, removed non-existent files (SplashView.swift, ShareSheet.swift)
- Updated app-store-review.md version from 1.0 to 2.2.0

## Files updated
- README.md
- CLAUDE.md
- .github/copilot-instructions.md
- docs/TESTING.md
- docs/a1c/QUICK_REFERENCE.md
- docs/a1c/IMPLEMENTATION_GUIDE.md
- docs/app-store-review.md

## Test plan
- [ ] Verify README CSV examples match actual app output
- [ ] Confirm no broken links in documentation