### PR TITLE
Fix: Improve memory management in CSV generation

### DIFF
--- a/HealthExporter/HealthExporter/CSVGenerator.swift
+++ b/HealthExporter/HealthExporter/CSVGenerator.swift
@@ -2,7 +2,7 @@ import HealthKit
 
 class CSVGenerator {
 
-    private static let csvHeader = "Date,Metric,Value,Unit,Source"
+    static let csvHeader = "Date,Metric,Value,Unit,Source"
 
     private static func makeDateFormatter(for option: DateFormatOption) -> DateFormatter {
         let formatter = DateFormatter()
@@ -21,84 +21,87 @@ class CSVGenerator {
         return field
     }
 
-    static func generateWeightCSV(from samples: [HKQuantitySample], unit: WeightUnit, dateFormat: DateFormatOption = .yyyyMMddHHmmss, sortOrder: SortOrder = .ascending) -> String {
+    // MARK: - Append methods (memory-efficient, sort in-place, write directly to string)
+
+    static func appendWeightRows(to csv: inout String, samples: inout [HKQuantitySample], unit: WeightUnit, dateFormat: DateFormatOption = .yyyyMMddHHmmss, sortOrder: SortOrder = .ascending) {
         let dateFormatter = makeDateFormatter(for: dateFormat)
-        let sorted = samples.sorted { sortOrder == .ascending ? $0.startDate < $1.startDate : $0.startDate > $1.startDate }
-        var lines: [String] = [csvHeader]
-        lines.reserveCapacity(sorted.count + 1)
-        for sample in sorted {
+        samples.sort { sortOrder == .ascending ? $0.startDate < $1.startDate : $0.startDate > $1.startDate }
+        for sample in samples {
             let date = dateFormatter.string(from: sample.startDate)
             let weightKg = sample.quantity.doubleValue(for: HKUnit.gramUnit(with: .kilo))
             let (value, unitString) = convertWeight(weightKg, to: unit)
             let source = csvEscape(sample.sourceRevision.source.name)
-            lines.append("\(date),Weight,\(String(format: "%.2f", value)),\(unitString),\(source)")
+            csv.append("\(date),Weight,\(String(format: "%.2f", value)),\(unitString),\(source)\n")
         }
-        return lines.joined(separator: "\n") + "\n"
     }
 
-    static func generateStepsCSV(from samples: [HKQuantitySample], dateFormat: DateFormatOption = .yyyyMMddHHmmss, sortOrder: SortOrder = .ascending) -> String {
+    static func appendStepsRows(to csv: inout String, samples: inout [HKQuantitySample], dateFormat: DateFormatOption = .yyyyMMddHHmmss, sortOrder: SortOrder = .ascending) {
         let dateFormatter = makeDateFormatter(for: dateFormat)
-        let sorted = samples.sorted { sortOrder == .ascending ? $0.startDate < $1.startDate : $0.startDate > $1.startDate }
-        var lines: [String] = [csvHeader]
-        lines.reserveCapacity(sorted.count + 1)
-        for sample in sorted {
+        samples.sort { sortOrder == .ascending ? $0.startDate < $1.startDate : $0.startDate > $1.startDate }
+        for sample in samples {
             let date = dateFormatter.string(from: sample.startDate)
             let steps = sample.quantity.doubleValue(for: HKUnit.count())
             let source = csvEscape(sample.sourceRevision.source.name)
-            lines.append("\(date),Steps,\(Int(steps)),steps,\(source)")
+            csv.append("\(date),Steps,\(Int(steps)),steps,\(source)\n")
         }
-        return lines.joined(separator: "\n") + "\n"
+    }
+
+    static func appendGlucoseRows(to csv: inout String, samples: inout [GlucoseSampleMgDl], dateFormat: DateFormatOption = .yyyyMMddHHmmss, sortOrder: SortOrder = .ascending) {
+        let dateFormatter = makeDateFormatter(for: dateFormat)
+        samples.sort { sortOrder == .ascending ? $0.startDate < $1.startDate : $0.startDate > $1.startDate }
+        for sample in samples {
+            let date = dateFormatter.string(from: sample.startDate)
+            let source = csvEscape(sample.source)
+            csv.append("\(date),Blood Glucose,\(String(format: "%.0f", sample.value)),mg/dL,\(source)\n")
+        }
+    }
+
+    static func appendA1CRows(to csv: inout String, samples: inout [A1CSample], dateFormat: DateFormatOption = .yyyyMMddHHmmss, sortOrder: SortOrder = .ascending) {
+        let dateFormatter = makeDateFormatter(for: dateFormat)
+        samples.sort { sortOrder == .ascending ? $0.effectiveDateTime < $1.effectiveDateTime : $0.effectiveDateTime > $1.effectiveDateTime }
+        for sample in samples {
+            let date = dateFormatter.string(from: sample.effectiveDateTime)
+            let source = csvEscape(sample.source)
+            csv.append("\(date),Hemoglobin A1C,\(String(format: "%.2f", sample.value)),\(sample.unit),\(source)\n")
+        }
+    }
+
+    // MARK: - Legacy convenience methods (used by tests and single-metric exports)
+
+    static func generateWeightCSV(from samples: [HKQuantitySample], unit: WeightUnit, dateFormat: DateFormatOption = .yyyyMMddHHmmss, sortOrder: SortOrder = .ascending) -> String {
+        var csv = csvHeader + "\n"
+        var mutableSamples = samples
+        appendWeightRows(to: &csv, samples: &mutableSamples, unit: unit, dateFormat: dateFormat, sortOrder: sortOrder)
+        return csv
+    }
+
+    static func generateStepsCSV(from samples: [HKQuantitySample], dateFormat: DateFormatOption = .yyyyMMddHHmmss, sortOrder: SortOrder = .ascending) -> String {
+        var csv = csvHeader + "\n"
+        var mutableSamples = samples
+        appendStepsRows(to: &csv, samples: &mutableSamples, dateFormat: dateFormat, sortOrder: sortOrder)
+        return csv
     }
 
     static func generateCombinedCSV(weightSamples: [HKQuantitySample]?, stepsSamples: [HKQuantitySample]?, glucoseSamples: [GlucoseSampleMgDl]?, a1cSamples: [A1CSample]?, weightUnit: WeightUnit, dateFormat: DateFormatOption = .yyyyMMddHHmmss, sortOrder: SortOrder = .ascending) -> String {
-        let dateFormatter = makeDateFormatter(for: dateFormat)
-        let ascending = sortOrder == .ascending
-        var lines: [String] = [csvHeader]
+        var csv = csvHeader + "\n"
 
-        if let weightSamples = weightSamples {
-            let sorted = weightSamples.sorted { ascending ? $0.startDate < $1.startDate : $0.startDate > $1.startDate }
-            lines.reserveCapacity(lines.capacity + sorted.count)
-            for sample in sorted {
-                let date = dateFormatter.string(from: sample.startDate)
-                let weightKg = sample.quantity.doubleValue(for: HKUnit.gramUnit(with: .kilo))
-                let (value, unitString) = convertWeight(weightKg, to: weightUnit)
-                let source = csvEscape(sample.sourceRevision.source.name)
-                lines.append("\(date),Weight,\(String(format: "%.2f", value)),\(unitString),\(source)")
-            }
+        if var samples = weightSamples {
+            appendWeightRows(to: &csv, samples: &samples, unit: weightUnit, dateFormat: dateFormat, sortOrder: sortOrder)
         }
 
-        if let stepsSamples = stepsSamples {
-            let sorted = stepsSamples.sorted { ascending ? $0.startDate < $1.startDate : $0.startDate > $1.startDate }
-            lines.reserveCapacity(lines.capacity + sorted.count)
-            for sample in sorted {
-                let date = dateFormatter.string(from: sample.startDate)
-                let steps = sample.quantity.doubleValue(for: HKUnit.count())
-                let source = csvEscape(sample.sourceRevision.source.name)
-                lines.append("\(date),Steps,\(Int(steps)),steps,\(source)")
-            }
+        if var samples = stepsSamples {
+            appendStepsRows(to: &csv, samples: &samples, dateFormat: dateFormat, sortOrder: sortOrder)
         }
 
-        if let glucoseSamples = glucoseSamples {
-            let sorted = glucoseSamples.sorted { ascending ? $0.startDate < $1.startDate : $0.startDate > $1.startDate }
-            lines.reserveCapacity(lines.capacity + sorted.count)
-            for sample in sorted {
-                let date = dateFormatter.string(from: sample.startDate)
-                let source = csvEscape(sample.source)
-                lines.append("\(date),Blood Glucose,\(String(format: "%.0f", sample.value)),mg/dL,\(source)")
-            }
+        if var samples = glucoseSamples {
+            appendGlucoseRows(to: &csv, samples: &samples, dateFormat: dateFormat, sortOrder: sortOrder)
         }
 
-        if let a1cSamples = a1cSamples {
-            let sorted = a1cSamples.sorted { ascending ? $0.effectiveDateTime < $1.effectiveDateTime : $0.effectiveDateTime > $1.effectiveDateTime }
-            lines.reserveCapacity(lines.capacity + sorted.count)
-            for sample in sorted {
-                let date = dateFormatter.string(from: sample.effectiveDateTime)
-                let source = csvEscape(sample.source)
-                lines.append("\(date),Hemoglobin A1C,\(String(format: "%.2f", sample.value)),\(sample.unit),\(source)")
-            }
+        if var samples = a1cSamples {
+            appendA1CRows(to: &csv, samples: &samples, dateFormat: dateFormat, sortOrder: sortOrder)
         }
 
-        return lines.joined(separator: "\n") + "\n"
+        return csv
     }
 
     private static func convertWeight(_ weightKg: Double, to unit: WeightUnit) -> (Double, String) {

--- a/HealthExporter/HealthExporter/DataSelectionView.swift
+++ b/HealthExporter/HealthExporter/DataSelectionView.swift
@@ -333,12 +333,33 @@ struct DataSelectionView: View {
                     return
                 }
 
-                csvContent = CSVGenerator.generateCombinedCSV(weightSamples: weightSamples, stepsSamples: stepsSamples, glucoseSamples: glucoseSamples, a1cSamples: a1cSamples, weightUnit: self.settings.weightUnit, dateFormat: self.settings.dateFormat, sortOrder: self.settings.sortOrder)
+                let dateFormat = self.settings.dateFormat
+                let sortOrder = self.settings.sortOrder
+                let weightUnit = self.settings.weightUnit
 
-                weightSamples = nil
-                stepsSamples = nil
-                glucoseSamples = nil
-                a1cSamples = nil
+                var csv = CSVGenerator.csvHeader + "\n"
+
+                if var samples = weightSamples {
+                    weightSamples = nil
+                    CSVGenerator.appendWeightRows(to: &csv, samples: &samples, unit: weightUnit, dateFormat: dateFormat, sortOrder: sortOrder)
+                }
+
+                if var samples = stepsSamples {
+                    stepsSamples = nil
+                    CSVGenerator.appendStepsRows(to: &csv, samples: &samples, dateFormat: dateFormat, sortOrder: sortOrder)
+                }
+
+                if var samples = glucoseSamples {
+                    glucoseSamples = nil
+                    CSVGenerator.appendGlucoseRows(to: &csv, samples: &samples, dateFormat: dateFormat, sortOrder: sortOrder)
+                }
+
+                if var samples = a1cSamples {
+                    a1cSamples = nil
+                    CSVGenerator.appendA1CRows(to: &csv, samples: &samples, dateFormat: dateFormat, sortOrder: sortOrder)
+                }
+
+                csvContent = csv
 
                 let dateFormatter = DateFormatter()
                 dateFormatter.dateFormat = "yyyy-MM-dd_HHmmss"


### PR DESCRIPTION
## Summary
- Refactor CSVGenerator to use in-place sorting (`inout` arrays) and direct string appending instead of creating sorted copies and `[String]` arrays with `joined()`
- Add `appendWeightRows`, `appendStepsRows`, `appendGlucoseRows`, `appendA1CRows` methods that write directly to an `inout String`
- Update DataSelectionView export flow to build CSV incrementally, releasing each metric's sample array immediately after processing

Fixes #44

## Test plan
- [x] All 51 existing tests pass (24 CSVGeneratorTests, 6 DateRangeOptionTests, 12 GlucoseSampleTests, 9 HealthMetricConfigTests)
- [ ] Manual test on device: export with multiple metrics selected, verify CSV output unchanged
- [ ] Manual test on device: export large dataset, verify no memory pressure warnings