### PR TITLE
Remove BuildConfig paid-account gate

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,11 +24,10 @@ HealthExporter/
 │       ├── SettingsView.swift        # Settings: export format, units, test data
 │       ├── SettingsManager.swift     # Settings persistence with UserDefaults
 │       ├── HealthKitManager.swift    # HealthKit authorization & queries
-│       ├── HealthMetricConfig.swift  # Metric configuration with availability rules
+│       ├── HealthMetricConfig.swift  # Central metric registry
 │       ├── HealthSampleTypes.swift   # Glucose, A1C, FHIR parsing
 │       ├── CSVGenerator.swift        # CSV generation with unit conversion, date format, sort order
 │       ├── CSVDocument.swift         # FileDocument for SwiftUI fileExporter
-│       ├── BuildConfig.swift         # Feature flags (paid account gating)
 │       ├── DateRangeOption.swift     # Date range selection enum
 │       ├── ExportError.swift         # Localized error types
 │       ├── PrivacyPolicyView.swift   # Privacy policy & disclaimer view
@@ -47,7 +46,7 @@ HealthExporter/
 ### Managers
 - **HealthKitManager**: Handles HealthKit authorization and data fetching with optional date range filtering
 - **SettingsManager**: ObservableObject that persists unit preferences, date format, and sort order via UserDefaults
-- **HealthMetricConfig**: Defines metric metadata including `requiresPaidAccount` flag and availability checks
+- **HealthMetricConfig**: Defines the supported export metrics
 
 ### Utilities
 - **CSVGenerator**: Converts HKQuantitySample arrays to CSV strings with unit conversion
@@ -65,21 +64,19 @@ HealthExporter/
 ## Required Capabilities
 
 - **HealthKit**: Must be enabled in Signing & Capabilities
-- **Clinical Health Records** (A1C): Enable capability if `BuildConfig.hasPaidDeveloperAccount == true`
+- **Clinical Health Records** (A1C): Enable capability for A1C export
 - **Info.plist Keys** (set via Build Settings as INFOPLIST_KEY_*):
     - `NSHealthShareUsageDescription`
     - `NSHealthClinicalHealthRecordsShareUsageDescription` (required for A1C export)
 
 ## Supported Health Metrics
 
-| Metric | HealthKit Identifier | Units | Requires Paid Account |
-|--------|---------------------|-------|----------------------|
-| Weight | `.bodyMass` | kg, lbs | No |
-| Steps | `.stepCount` | count | No |
-| Blood Glucose | `.bloodGlucose` | mg/dL | No |
-| Hemoglobin A1C | `.labResultRecord` (Clinical) | % | Yes (paid account required) |
-
-**Important**: Metric availability is centrally managed in `HealthMetricConfig.swift`. Each metric has a `requiresPaidAccount` boolean that determines if it's available based on `BuildConfig.hasPaidDeveloperAccount`.
+| Metric | HealthKit Identifier | Units |
+|--------|---------------------|-------|
+| Weight | `.bodyMass` | kg, lbs |
+| Steps | `.stepCount` | count |
+| Blood Glucose | `.bloodGlucose` | mg/dL |
+| Hemoglobin A1C | `.labResultRecord` (Clinical) | % |
 
 ## CSV Output Format
 
@@ -115,35 +112,18 @@ Filename format: `HealthExporter_YYYY-MM-DD_HHMMSS.csv`
 
 ### Testing Status
 
-- Hemoglobin A1C export has been verified working end-to-end on a physical device with Clinical Health Records enabled. The feature is gated behind `BuildConfig.hasPaidDeveloperAccount`.
+- Hemoglobin A1C export has been verified working end-to-end on a physical device with Clinical Health Records enabled.
 
-### Metric Availability Pattern
+### Metric Pattern
 
-**CRITICAL**: When adding metrics that require paid features:
+**CRITICAL**: When adding metrics:
 
-1. Define the metric in `HealthMetricConfig.swift` with `requiresPaidAccount: true/false`
-2. Use `HealthMetrics.{metric}.isAvailable` to check availability everywhere
-3. In `DataSelectionView`, use a custom `Binding` that:
-   - Returns `false` when metric is unavailable (even if stored setting is `true`)
-   - Only allows setting to `true` if metric is available
-   - Forces value to `false` if unavailable
-4. In `SettingsManager.init()`, force unavailable metrics to `false` and clear from UserDefaults
-5. In `hasSelectedMetric`, only count metrics where `isAvailable && setting == true`
-6. This prevents UI/state mismatches where disabled metrics appear selected
-
-**Example** (A1C toggle in DataSelectionView):
-```swift
-Toggle("", isOn: Binding(
-    get: { HealthMetrics.a1c.isAvailable && settings.exportA1C },
-    set: { newValue in
-        if HealthMetrics.a1c.isAvailable {
-            settings.exportA1C = newValue
-        } else {
-            settings.exportA1C = false
-        }
-    }
-))
-```
+1. Define the metric in `HealthMetricConfig.swift`
+2. Add authorization and fetching support in `HealthKitManager`
+3. Add a normal toggle in `DataSelectionView`
+4. Persist the setting in `SettingsManager`
+5. Update `hasSelectedMetric` and CSV generation
+6. Add tests and documentation
 
 ## Memory Optimization Directive
 
@@ -172,15 +152,14 @@ Toggle("", isOn: Binding(
 ## Future Expansion
 
 When adding new health data types:
-1. Add the metric to `HealthMetricConfig.swift` with appropriate `requiresPaidAccount` value
+1. Add the metric to `HealthMetricConfig.swift`
 2. Add new quantity type identifiers in `HealthKitManager.requestAuthorization()` (only if available)
 3. Create new fetch methods in `HealthKitManager` for each data type
-4. Add corresponding toggle in `DataSelectionView` using the metric availability pattern (see Development Notes)
+4. Add corresponding toggle in `DataSelectionView` (see Development Notes)
 5. Extend `CSVGenerator.generateCombinedCSV()` with the new data type
 6. Add unit conversion logic if applicable
-7. Update SettingsManager initialization to handle unavailable metrics (force to false)
-8. Update SettingsManager/SettingsView if new unit preferences are needed
-9. **Ensure new data types follow memory optimization practices** - release samples after CSV generation
+7. Update SettingsManager/SettingsView if new preferences are needed
+8. **Ensure new data types follow memory optimization practices** - release samples after CSV generation
 
 ## Code Style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,10 +31,9 @@ xcodebuild -project HealthExporter.xcodeproj -scheme HealthExporter -configurati
 | File | Role |
 |------|------|
 | `HealthKitManager.swift` | HealthKit authorization + data fetching; uses DispatchGroup for parallel concurrent queries |
-| `HealthMetricConfig.swift` | Central metric registry with `requiresPaidAccount` flags and `isAvailable` checks |
-| `SettingsManager.swift` | `@ObservableObject` persisting unit/format prefs to UserDefaults; forces unavailable metrics to `false` at init |
+| `HealthMetricConfig.swift` | Central metric registry for supported export metrics |
+| `SettingsManager.swift` | `@ObservableObject` persisting unit/format prefs to UserDefaults |
 | `CSVGenerator.swift` | Converts HKQuantitySample arrays → CSV string with unit conversion, configurable date format and sort order |
-| `BuildConfig.swift` | Feature flag: `hasPaidDeveloperAccount` gates A1C availability |
 | `DataSelectionView.swift` | Main UI: metric toggles, date range picker, Save/Share export buttons |
 
 ### Export Flow
@@ -47,23 +46,14 @@ xcodebuild -project HealthExporter.xcodeproj -scheme HealthExporter -configurati
 
 ## Critical Patterns
 
-### Metric Availability (MUST follow this pattern)
-Metric availability is centrally managed in `HealthMetricConfig.swift`. When gating a metric on a paid account:
+### Metric Registry
+Supported metrics are centralized in `HealthMetricConfig.swift`. If you add a new metric:
 
-1. Set `requiresPaidAccount: true` in `HealthMetricConfig.swift`
-2. Use `HealthMetrics.{metric}.isAvailable` everywhere — never check `BuildConfig` directly
-3. In `DataSelectionView`, use a custom `Binding` that enforces unavailability:
-```swift
-Toggle("", isOn: Binding(
-    get: { HealthMetrics.a1c.isAvailable && settings.exportA1C },
-    set: { newValue in
-        if HealthMetrics.a1c.isAvailable { settings.exportA1C = newValue }
-        else { settings.exportA1C = false }
-    }
-))
-```
-4. In `SettingsManager.init()`, force unavailable metrics to `false` and remove from UserDefaults
-5. In `hasSelectedMetric`, only count metrics where `isAvailable && setting == true`
+1. Add it to `HealthMetrics`
+2. Add authorization/fetching support in `HealthKitManager`
+3. Add a toggle in `DataSelectionView`
+4. Persist its setting in `SettingsManager`
+5. Extend CSV generation and tests
 
 ### Memory Management (CRITICAL)
 HealthKit datasets can be very large. Always:
@@ -73,13 +63,13 @@ HealthKit datasets can be very large. Always:
 - Pre-allocate with `lines.reserveCapacity(...)` when count is known
 
 ### Adding a New Metric
-1. Add to `HealthMetricConfig.swift` with `requiresPaidAccount` value
+1. Add to `HealthMetricConfig.swift`
 2. Add quantity type to `HealthKitManager.requestAuthorization()`
 3. Add fetch method in `HealthKitManager`
-4. Add toggle in `DataSelectionView` using the availability binding pattern above
+4. Add toggle in `DataSelectionView`
 5. Extend `CSVGenerator.generateCombinedCSV()` for the new type
 6. Add unit conversion if needed
-7. Update `SettingsManager.init()` to force unavailable metrics to `false`
+7. Update `SettingsManager` persistence if needed
 8. Release samples after CSV generation (memory optimization)
 
 ## CSV Format
@@ -103,12 +93,12 @@ Date,Metric,Value,Unit,Source
 ## Required Capabilities
 
 - **HealthKit**: Always required (enabled in Signing & Capabilities)
-- **Clinical Health Records**: Required for A1C; only enable when `BuildConfig.hasPaidDeveloperAccount == true`
+- **Clinical Health Records**: Required for A1C export
 - Info.plist keys set via Build Settings (`INFOPLIST_KEY_*`): `NSHealthShareUsageDescription`, `NSHealthClinicalHealthRecordsShareUsageDescription`
 
 ## A1C Status
 
-Hemoglobin A1C export has been verified working on a physical device with Clinical Health Records enabled. The feature is gated behind `BuildConfig.hasPaidDeveloperAccount`. See `docs/a1c/` for FHIR/LOINC implementation details.
+Hemoglobin A1C export has been verified working on a physical device with Clinical Health Records enabled. See `docs/a1c/` for FHIR/LOINC implementation details.
 
 ## Documentation
 

--- a/HealthExporter/HealthExporter/BuildConfig.swift
+++ b/HealthExporter/HealthExporter/BuildConfig.swift
@@ -1,8 +1,0 @@
-import Foundation
-
-/// Build configuration for paid/free developer accounts
-struct BuildConfig {
-    /// Set to true if you have a paid Apple Developer account with Clinical Health Records entitlement
-    /// Set to false for free accounts (disables clinical records features)
-    static let hasPaidDeveloperAccount = true
-}

--- a/HealthExporter/HealthExporter/DataSelectionView.swift
+++ b/HealthExporter/HealthExporter/DataSelectionView.swift
@@ -37,7 +37,7 @@ struct DataSelectionView: View {
         settings.exportWeight ||
         settings.exportSteps ||
         settings.exportGlucose ||
-        (HealthMetrics.a1c.isAvailable && settings.exportA1C)
+        settings.exportA1C
     }
 
     private func updateExportEnabled() {
@@ -82,44 +82,26 @@ struct DataSelectionView: View {
             HStack {
                 HStack(spacing: 4) {
                     Text("Hemoglobin A1C (%)")
-                    if HealthMetrics.a1c.isAvailable {
-                        Image(systemName: "cross.case")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    } else {
-                        Text("💰")
-                            .font(.caption)
-                    }
+                    Image(systemName: "cross.case")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
                 }
                 Spacer()
-                Toggle("", isOn: Binding(
-                    get: { HealthMetrics.a1c.isAvailable && settings.exportA1C },
-                    set: { newValue in
-                        if HealthMetrics.a1c.isAvailable {
-                            settings.exportA1C = newValue
-                        } else {
-                            settings.exportA1C = false
-                        }
-                    }
-                ))
+                Toggle("", isOn: $settings.exportA1C)
                 .labelsHidden()
             }
             .padding(.horizontal)
-            .opacity(HealthMetrics.a1c.isAvailable ? 1.0 : 0.5)
-            .disabled(!HealthMetrics.a1c.isAvailable)
 
-            if HealthMetrics.a1c.isAvailable {
-                HStack(spacing: 4) {
-                    Image(systemName: "cross.case")
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
-                    Text("Requires access to Clinical Health Records")
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
-                }
-                .padding(.horizontal)
-                .frame(maxWidth: .infinity, alignment: .leading)
+            HStack(spacing: 4) {
+                Image(systemName: "cross.case")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                Text("Requires access to Clinical Health Records")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
             }
+            .padding(.horizontal)
+            .frame(maxWidth: .infinity, alignment: .leading)
 
             Divider()
                 .padding()

--- a/HealthExporter/HealthExporter/HealthKitManager.swift
+++ b/HealthExporter/HealthExporter/HealthKitManager.swift
@@ -18,7 +18,7 @@ class HealthKitManager {
         var typesToRead: Set<HKObjectType> = [weightType, stepsType, glucoseType]
 
         // Only request Clinical Records access when A1C is actually selected
-        if includeA1C, HealthMetrics.a1c.isAvailable,
+        if includeA1C,
            let clinicalType = HKObjectType.clinicalType(forIdentifier: .labResultRecord) {
             typesToRead.insert(clinicalType)
         }

--- a/HealthExporter/HealthExporter/HealthMetricConfig.swift
+++ b/HealthExporter/HealthExporter/HealthMetricConfig.swift
@@ -1,35 +1,25 @@
 import Foundation
 
-/// Configuration for health metrics including availability requirements
+/// Configuration for supported health metrics.
 struct HealthMetricConfig {
     let name: String
-    let requiresPaidAccount: Bool
-    
-    /// Returns true if this metric is available based on current account status
-    var isAvailable: Bool {
-        !requiresPaidAccount || BuildConfig.hasPaidDeveloperAccount
-    }
 }
 
 /// Centralized configuration for all health metrics
 enum HealthMetrics {
     static let weight = HealthMetricConfig(
-        name: "Weight",
-        requiresPaidAccount: false
+        name: "Weight"
     )
     
     static let steps = HealthMetricConfig(
-        name: "Steps",
-        requiresPaidAccount: false
+        name: "Steps"
     )
     
     static let glucose = HealthMetricConfig(
-        name: "Blood Glucose",
-        requiresPaidAccount: false
+        name: "Blood Glucose"
     )
     
     static let a1c = HealthMetricConfig(
-        name: "Hemoglobin A1C",
-        requiresPaidAccount: true
+        name: "Hemoglobin A1C"
     )
 }

--- a/HealthExporter/HealthExporter/SettingsManager.swift
+++ b/HealthExporter/HealthExporter/SettingsManager.swift
@@ -87,14 +87,7 @@ class SettingsManager: ObservableObject {
         self.exportSteps = UserDefaults.standard.object(forKey: "exportSteps") as? Bool ?? true
         self.exportGlucose = UserDefaults.standard.object(forKey: "exportGlucose") as? Bool ?? false
 
-        // A1C: Only enable if available AND user preference says so
-        // Force to false if not available (free tier account)
-        if HealthMetrics.a1c.isAvailable {
-            self.exportA1C = UserDefaults.standard.object(forKey: "exportA1C") as? Bool ?? false
-        } else {
-            self.exportA1C = false
-            UserDefaults.standard.set(false, forKey: "exportA1C")
-        }
+        self.exportA1C = UserDefaults.standard.object(forKey: "exportA1C") as? Bool ?? false
 
         // Persist changes via Combine subscribers (avoids @Published + didSet crash)
         $temperatureUnit

--- a/HealthExporterTests/HealthMetricConfigTests.swift
+++ b/HealthExporterTests/HealthMetricConfigTests.swift
@@ -3,54 +3,22 @@ import XCTest
 
 final class HealthMetricConfigTests: XCTestCase {
 
-    // MARK: - HealthMetricConfig.isAvailable
-
-    func testIsAvailable_whenNotRequiringPaidAccount_isAlwaysTrue() {
-        let config = HealthMetricConfig(name: "Free Metric", requiresPaidAccount: false)
-        XCTAssertTrue(config.isAvailable)
-    }
-
-    func testIsAvailable_whenRequiringPaidAccount_matchesBuildConfig() {
-        let config = HealthMetricConfig(name: "Paid Metric", requiresPaidAccount: true)
-        // isAvailable should be true only when BuildConfig.hasPaidDeveloperAccount is true
-        XCTAssertEqual(config.isAvailable, BuildConfig.hasPaidDeveloperAccount)
-    }
-
     // MARK: - HealthMetrics static properties
 
-    func testWeight_doesNotRequirePaidAccount() {
-        XCTAssertFalse(HealthMetrics.weight.requiresPaidAccount)
+    func testWeight_hasExpectedName() {
         XCTAssertEqual(HealthMetrics.weight.name, "Weight")
-        XCTAssertTrue(HealthMetrics.weight.isAvailable)
     }
 
-    func testSteps_doesNotRequirePaidAccount() {
-        XCTAssertFalse(HealthMetrics.steps.requiresPaidAccount)
+    func testSteps_hasExpectedName() {
         XCTAssertEqual(HealthMetrics.steps.name, "Steps")
-        XCTAssertTrue(HealthMetrics.steps.isAvailable)
     }
 
-    func testGlucose_doesNotRequirePaidAccount() {
-        XCTAssertFalse(HealthMetrics.glucose.requiresPaidAccount)
+    func testGlucose_hasExpectedName() {
         XCTAssertEqual(HealthMetrics.glucose.name, "Blood Glucose")
-        XCTAssertTrue(HealthMetrics.glucose.isAvailable)
     }
 
-    func testA1C_requiresPaidAccount() {
-        XCTAssertTrue(HealthMetrics.a1c.requiresPaidAccount)
+    func testA1C_hasExpectedName() {
         XCTAssertEqual(HealthMetrics.a1c.name, "Hemoglobin A1C")
-    }
-
-    func testA1C_isAvailability_matchesBuildConfig() {
-        XCTAssertEqual(HealthMetrics.a1c.isAvailable, BuildConfig.hasPaidDeveloperAccount)
-    }
-
-    func testA1C_isUnavailable_whenFreeAccount() {
-        // With BuildConfig.hasPaidDeveloperAccount = false (the default), A1C should be unavailable
-        if !BuildConfig.hasPaidDeveloperAccount {
-            XCTAssertFalse(HealthMetrics.a1c.isAvailable,
-                "A1C should be unavailable when hasPaidDeveloperAccount is false")
-        }
     }
 
     // MARK: - LOINCCode constants

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A privacy-focused iOS app that exports Apple HealthKit data to CSV files. All da
 - **CSV export**: Save directly to Files app via `.fileExporter()`
 - **Splash screen** with navigation to data selection and settings
 - **Settings persistence**: Unit preferences are automatically saved
-- **Availability gating**: A1C export requires Clinical Health Records capability and a paid Apple Developer account
+- **Clinical records support**: A1C export requires Clinical Health Records capability and permission
 - **Memory-optimized**: Health data is cleared from memory immediately after export
 
 ## Screenshots
@@ -39,7 +39,7 @@ A privacy-focused iOS app that exports Apple HealthKit data to CSV files. All da
 
 1. Open `HealthExporter.xcodeproj` in Xcode
 2. Ensure HealthKit is enabled in Signing & Capabilities
-3. If using Hemoglobin A1C export with a paid Apple Developer account, enable **Clinical Health Records** capability (see [A1C docs](docs/a1c/) for details)
+3. If using Hemoglobin A1C export, enable **Clinical Health Records** capability (see [A1C docs](docs/a1c/) for details)
 4. Build and run on a physical device (HealthKit has limited simulator support)
 
 ## Usage
@@ -47,7 +47,7 @@ A privacy-focused iOS app that exports Apple HealthKit data to CSV files. All da
 1. Launch the app (splash screen displays briefly)
 2. (Optional) Tap the gear icon to configure unit preferences or view the privacy policy
 3. Tap "Next" to go to the data selection screen
-4. Select metrics to export (Weight, Steps, Blood Glucose, A1C — A1C only if available)
+4. Select metrics to export (Weight, Steps, Blood Glucose, A1C)
 5. Choose a date range option (last X days, last X records, date range, or all data)
 6. Tap "Save..." to save to Files
 
@@ -89,7 +89,7 @@ Data can be sorted ascending (oldest first) or descending (newest first) within 
 - iOS 26+
 - Physical iOS device (for full HealthKit functionality)
 - HealthKit access permission
-- Clinical Health Records capability and user permission (for A1C export; paid Apple Developer account required)
+- Clinical Health Records capability and user permission (for A1C export)
 
 ## Testing
 
@@ -104,7 +104,7 @@ Unit tests run automatically in GitHub Actions CI on every push and PR. See [doc
 
 ### A1C Testing Status
 
-Hemoglobin A1C export has been **verified working end-to-end** on a physical device with Clinical Health Records enabled. The feature is gated behind `BuildConfig.hasPaidDeveloperAccount`. See [docs/a1c/](docs/a1c/) for implementation details.
+Hemoglobin A1C export has been **verified working end-to-end** on a physical device with Clinical Health Records enabled. See [docs/a1c/](docs/a1c/) for implementation details.
 
 ## Project Structure
 
@@ -128,7 +128,6 @@ HealthExporter/
 │       ├── SettingsManager.swift        # UserDefaults persistence
 │       ├── DateRangeOption.swift        # Date range selection enum
 │       ├── ExportError.swift            # Localized error types
-│       ├── BuildConfig.swift            # Feature flags
 │       └── Assets.xcassets/
 ├── HealthExporterTests/
 │   ├── CSVGeneratorTests.swift

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -12,7 +12,7 @@ Tests live in `HealthExporterTests/` (sibling to the main `HealthExporter/` sour
 |------|--------------|
 | `CSVGeneratorTests.swift` | CSV generation for weight, steps, glucose, A1C; unit conversion (kg→lbs); output formatting |
 | `DateRangeOptionTests.swift` | `DateRangeOption` enum cases, raw values, `displayName` |
-| `HealthMetricConfigTests.swift` | `HealthMetricConfig.isAvailable`, `HealthMetrics` static properties, `LOINCCode` constants |
+| `HealthMetricConfigTests.swift` | `HealthMetrics` static properties and `LOINCCode` constants |
 | `GlucoseSampleTests.swift` | `GlucoseSampleMgDl` init — values ≥20 accepted, values <20 rejected |
 ## Running Tests Locally
 

--- a/docs/a1c/IMPLEMENTATION_GUIDE.md
+++ b/docs/a1c/IMPLEMENTATION_GUIDE.md
@@ -38,6 +38,7 @@ func fetchA1CData(dateRange: (startDate: Date, endDate: Date)? = nil,
 - Added `@Published var exportA1C: Bool` property
 - Persists preference to UserDefaults with key `"exportA1C"`
 - Defaults to `false` on first app launch
+- A1C is treated as a standard supported metric; no developer-account gating remains
 
 ### 4. User Interface (DataSelectionView.swift)
 - Added toggle: "Hemoglobin A1C (%)"

--- a/docs/a1c/QUICK_REFERENCE.md
+++ b/docs/a1c/QUICK_REFERENCE.md
@@ -21,6 +21,7 @@
 - **File**: `SettingsManager.swift`
 - **New Property**: `@Published var exportA1C: Bool`
 - Persists to UserDefaults with key: `"exportA1C"`
+- No developer-account gating; A1C is a standard supported metric
 
 ### User Interface
 - **File**: `DataSelectionView.swift`
@@ -159,4 +160,3 @@ Add this key (adjust description as needed):
 4. App queries for lab results with LOINC code 4548-4
 5. A1C results combined with other selected metrics in CSV
 6. File saved/shared with all data in single CSV file
-


### PR DESCRIPTION
## Summary
- remove the obsolete `BuildConfig.hasPaidDeveloperAccount` gate and delete `BuildConfig.swift`
- make A1C a normal supported metric in the UI, settings, and HealthKit authorization flow
- update tests and repository docs to match the new always-available A1C behavior

## Testing
- `xcodebuild test -project HealthExporter.xcodeproj -scheme HealthExporter -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`

Closes #51