### PR TITLE
Remove stale HealthKit write usage key

### DIFF
--- a/HealthExporter.xcodeproj/project.pbxproj
+++ b/HealthExporter.xcodeproj/project.pbxproj
@@ -357,7 +357,6 @@
 				INFOPLIST_KEY_CFBundleDisplayName = HealthExporterCSV;
 				INFOPLIST_KEY_NSHealthClinicalHealthRecordsShareUsageDescription = "HealthExporter needs access to your clinical health records to export your Hemoglobin A1C results.";
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "HealthExporter needs access to your health data to export your weight, steps, and glucose measurements.";
-				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "HealthExporter does not write to HealthKit. This permission is not requested at runtime.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -395,7 +394,6 @@
 				INFOPLIST_KEY_CFBundleDisplayName = HealthExporterCSV;
 				INFOPLIST_KEY_NSHealthClinicalHealthRecordsShareUsageDescription = "HealthExporter needs access to your clinical health records to export your Hemoglobin A1C results.";
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "HealthExporter needs access to your health data to export your weight, steps, and glucose measurements.";
-				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "HealthExporter does not write to HealthKit. This permission is not requested at runtime.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;


### PR DESCRIPTION
## Summary
- remove `INFOPLIST_KEY_NSHealthUpdateUsageDescription` from the Debug and Release build settings
- keep the app aligned with its read-only HealthKit authorization flow
- verify the generated simulator app `Info.plist` no longer contains the write-usage key

## Testing
- `xcodebuild test -project HealthExporter.xcodeproj -scheme HealthExporter -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- verified generated `HealthExporter.app/Info.plist` still contains `NSHealthShareUsageDescription` and `NSHealthClinicalHealthRecordsShareUsageDescription`
- verified generated `HealthExporter.app/Info.plist` does not contain `NSHealthUpdateUsageDescription`

Closes #53