### PR TITLE
Align app branding and privacy messaging

### DIFF
--- a/HealthExporter.xcodeproj/project.pbxproj
+++ b/HealthExporter.xcodeproj/project.pbxproj
@@ -354,7 +354,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = HealthExporter/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = HealthExporterCSV;
+				INFOPLIST_KEY_CFBundleDisplayName = "HealthExporterCSV";
 				INFOPLIST_KEY_NSHealthClinicalHealthRecordsShareUsageDescription = "HealthExporter needs access to your clinical health records to export your Hemoglobin A1C results.";
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "HealthExporter needs access to your health data to export your weight, steps, and glucose measurements.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -391,7 +391,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = HealthExporter/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = HealthExporterCSV;
+				INFOPLIST_KEY_CFBundleDisplayName = "HealthExporterCSV";
 				INFOPLIST_KEY_NSHealthClinicalHealthRecordsShareUsageDescription = "HealthExporter needs access to your clinical health records to export your Hemoglobin A1C results.";
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "HealthExporter needs access to your health data to export your weight, steps, and glucose measurements.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;

--- a/HealthExporter/HealthExporter/LaunchView.swift
+++ b/HealthExporter/HealthExporter/LaunchView.swift
@@ -16,7 +16,7 @@ struct LaunchView: View {
                 .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
                 .shadow(radius: 8)
 
-            Text("Health Exporter")
+            Text("HealthExporterCSV")
                 .font(.largeTitle)
                 .fontWeight(.bold)
 

--- a/HealthExporter/HealthExporter/PrivacyPolicyView.swift
+++ b/HealthExporter/HealthExporter/PrivacyPolicyView.swift
@@ -23,7 +23,7 @@ struct PrivacyPolicyView: View {
                         • Weight
                         • Step Count
                         • Blood Glucose
-                        • Hemoglobin A1C (when available)
+                        • Hemoglobin A1C
 
                         You control exactly which data types to share through the Apple Health permissions dialog.
                         """)
@@ -33,7 +33,7 @@ struct PrivacyPolicyView: View {
                         Your health data is used solely to generate CSV export files on your device. Specifically:
 
                         • Data is read from HealthKit only when you initiate an export.
-                        • The CSV file is generated in memory and presented via the system share sheet or file picker.
+                        • The CSV file is generated in memory and presented through the system file picker.
                         • Health data is cleared from app memory immediately after export.
                         • No health data is stored persistently by the app.
                         """)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Health Exporter
+# HealthExporterCSV
 
 A privacy-focused iOS app that exports Apple HealthKit data to CSV files. All data processing happens entirely on-device — no health data is ever sent to external servers.
 
@@ -161,7 +161,7 @@ HealthExporter requests read-only access to the following Apple HealthKit data t
 - Weight
 - Step Count
 - Blood Glucose
-- Hemoglobin A1C (when available)
+- Hemoglobin A1C
 
 You control exactly which data types to share through the Apple Health permissions dialog.
 
@@ -170,7 +170,7 @@ You control exactly which data types to share through the Apple Health permissio
 Your health data is used solely to generate CSV export files on your device. Specifically:
 
 - Data is read from HealthKit only when you initiate an export
-- The CSV file is generated in memory and presented via the system share sheet or file picker
+- The CSV file is generated in memory and presented through the system file picker
 - Health data is cleared from app memory immediately after export
 - No health data is stored persistently by the app
 

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -19,7 +19,7 @@ HealthExporterCSV requests read-only access to the following Apple HealthKit dat
 - Weight
 - Step Count
 - Blood Glucose
-- Hemoglobin A1C (when available)
+- Hemoglobin A1C
 
 You control exactly which data types to share through the Apple Health permissions dialog.
 


### PR DESCRIPTION
## Summary
- align the in-app launch title with the shipped bundle display name
- update privacy/disclosure copy to match the current `.fileExporter()` save flow
- remove leftover wording that implied A1C was conditionally available

## Testing
- `xcodebuild test -project HealthExporter.xcodeproj -scheme HealthExporter -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`

Closes #54
Closes #55
Closes #56