### PR TITLE
Align docs and privacy copy

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -40,7 +40,7 @@ HealthExporter/
 
 ### Views
 - **LaunchView**: Welcome/splash screen with "Next" button and gear icon for Settings
-- **DataSelectionView**: Main screen with metric toggles (Weight, Steps, Blood Glucose, A1C), date pickers, and Save/Share buttons
+- **DataSelectionView**: Main screen with metric toggles (Weight, Steps, Blood Glucose, A1C), date pickers, and Save button
 - **SettingsView**: Export format (date format, sort order) and unit preference configuration (Temperature, Weight, Distance/Speed)
 
 ### Managers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,14 +34,14 @@ xcodebuild -project HealthExporter.xcodeproj -scheme HealthExporter -configurati
 | `HealthMetricConfig.swift` | Central metric registry for supported export metrics |
 | `SettingsManager.swift` | `@ObservableObject` persisting unit/format prefs to UserDefaults |
 | `CSVGenerator.swift` | Converts HKQuantitySample arrays → CSV string with unit conversion, configurable date format and sort order |
-| `DataSelectionView.swift` | Main UI: metric toggles, date range picker, Save/Share export buttons |
+| `DataSelectionView.swift` | Main UI: metric toggles, date range picker, Save export button |
 
 ### Export Flow
 1. User selects metrics + date range in `DataSelectionView`
 2. HealthKit authorization requested (if needed)
 3. `HealthKitManager` fetches selected metrics in parallel (DispatchGroup)
 4. `CSVGenerator.generateCombinedCSV()` builds output
-5. Save → SwiftUI `.fileExporter()` → Files app; Share → `ShareSheet` → `UIActivityViewController`
+5. Save → SwiftUI `.fileExporter()` → Files app
 6. Sample arrays and CSV content are cleared from memory immediately after export
 
 ## Critical Patterns

--- a/HealthExporter/HealthExporter/PrivacyPolicyView.swift
+++ b/HealthExporter/HealthExporter/PrivacyPolicyView.swift
@@ -14,11 +14,11 @@ struct PrivacyPolicyView: View {
                         .foregroundColor(.secondary)
 
                     sectionView(title: "Overview",
-                        body: "HealthExporter is designed with your privacy as a core principle. All data processing happens entirely on your device. No health data is ever sent to external servers, collected by the developer, or shared with third parties.")
+                        body: "HealthExporterCSV is designed with your privacy as a core principle. All data processing happens entirely on your device. No health data is ever sent to external servers, collected by the developer, or shared with third parties.")
 
                     sectionView(title: "Data We Access",
                         body: """
-                        HealthExporter requests read-only access to the following Apple HealthKit data types, only when you explicitly grant permission:
+                        HealthExporterCSV requests read-only access to the following Apple HealthKit data types, only when you explicitly grant permission:
 
                         • Weight
                         • Step Count
@@ -41,11 +41,11 @@ struct PrivacyPolicyView: View {
 
                 Group {
                     sectionView(title: "Data Storage",
-                        body: "The only data HealthExporter stores persistently is your preferences (unit selections, date format, sort order, and metric toggle states) in the app's local UserDefaults. No health data, personal identifiers, or usage analytics are stored.")
+                        body: "The only data HealthExporterCSV stores persistently is your preferences (unit selections, date format, sort order, and metric toggle states) in the app's local UserDefaults. No health data, personal identifiers, or usage analytics are stored.")
 
                     sectionView(title: "No Data Collection or Transmission",
                         body: """
-                        HealthExporter does not:
+                        HealthExporterCSV does not:
 
                         • Collect or transmit any data to external servers
                         • Include analytics, crash reporting, or tracking SDKs
@@ -55,7 +55,7 @@ struct PrivacyPolicyView: View {
                         """)
 
                     sectionView(title: "Your Control",
-                        body: "You can revoke HealthExporter's access to HealthKit data at any time through Settings > Health > Data Access & Devices on your iPhone. Revoking access does not affect any CSV files you have previously exported.")
+                        body: "You can revoke HealthExporterCSV's access to HealthKit data at any time through Settings > Health > Data Access & Devices on your iPhone. Revoking access does not affect any CSV files you have previously exported.")
 
                     sectionView(title: "Changes to This Policy",
                         body: "If this privacy policy is updated, the revised version will be included in an app update. The \"Last updated\" date at the top will reflect the most recent revision.")
@@ -70,16 +70,16 @@ struct PrivacyPolicyView: View {
                         .fontWeight(.bold)
 
                     sectionView(title: "No Warranty",
-                        body: "HealthExporter is provided \"as is\" without warranty of any kind, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose, and noninfringement.")
+                        body: "HealthExporterCSV is provided \"as is\" without warranty of any kind, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose, and noninfringement.")
 
                     sectionView(title: "Not Medical Advice",
-                        body: "HealthExporter is a data export utility. It does not provide medical advice, diagnosis, or treatment recommendations. The exported data is a reflection of what is stored in Apple HealthKit and should not be used as a substitute for professional medical judgment. Always consult a qualified healthcare provider with questions about your health.")
+                        body: "HealthExporterCSV is a data export utility. It does not provide medical advice, diagnosis, or treatment recommendations. The exported data is a reflection of what is stored in Apple HealthKit and should not be used as a substitute for professional medical judgment. Always consult a qualified healthcare provider with questions about your health.")
 
                     sectionView(title: "Limitation of Liability",
                         body: "In no event shall the developer be liable for any claim, damages, or other liability arising from the use or inability to use this app, including but not limited to data loss, inaccurate exports, or any decisions made based on exported data.")
 
                     sectionView(title: "Data Accuracy",
-                        body: "HealthExporter exports data as recorded in Apple HealthKit. The developer makes no guarantees about the accuracy, completeness, or reliability of the underlying health data or the exported CSV files.")
+                        body: "HealthExporterCSV exports data as recorded in Apple HealthKit. The developer makes no guarantees about the accuracy, completeness, or reliability of the underlying health data or the exported CSV files.")
                 }
             }
             .padding()

--- a/README.md
+++ b/README.md
@@ -152,11 +152,11 @@ HealthExporter/
 
 ### Overview
 
-HealthExporter is designed with your privacy as a core principle. All data processing happens entirely on your device. No health data is ever sent to external servers, collected by the developer, or shared with third parties.
+HealthExporterCSV is designed with your privacy as a core principle. All data processing happens entirely on your device. No health data is ever sent to external servers, collected by the developer, or shared with third parties.
 
 ### Data We Access
 
-HealthExporter requests read-only access to the following Apple HealthKit data types, only when you explicitly grant permission:
+HealthExporterCSV requests read-only access to the following Apple HealthKit data types, only when you explicitly grant permission:
 
 - Weight
 - Step Count
@@ -176,11 +176,11 @@ Your health data is used solely to generate CSV export files on your device. Spe
 
 ### Data Storage
 
-The only data HealthExporter stores persistently is your preferences (unit selections, date format, sort order, and metric toggle states) in the app's local UserDefaults. No health data, personal identifiers, or usage analytics are stored.
+The only data HealthExporterCSV stores persistently is your preferences (unit selections, date format, sort order, and metric toggle states) in the app's local UserDefaults. No health data, personal identifiers, or usage analytics are stored.
 
 ### No Data Collection or Transmission
 
-HealthExporter does not:
+HealthExporterCSV does not:
 
 - Collect or transmit any data to external servers
 - Include analytics, crash reporting, or tracking SDKs
@@ -190,7 +190,7 @@ HealthExporter does not:
 
 ### Your Control
 
-You can revoke HealthExporter's access to HealthKit data at any time through **Settings > Health > Data Access & Devices** on your iPhone. Revoking access does not affect any CSV files you have previously exported.
+You can revoke HealthExporterCSV's access to HealthKit data at any time through **Settings > Health > Data Access & Devices** on your iPhone. Revoking access does not affect any CSV files you have previously exported.
 
 ### Changes to This Policy
 
@@ -200,11 +200,11 @@ If this privacy policy is updated, the revised version will be included in an ap
 
 ### No Warranty
 
-HealthExporter is provided "as is" without warranty of any kind, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose, and noninfringement.
+HealthExporterCSV is provided "as is" without warranty of any kind, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose, and noninfringement.
 
 ### Not Medical Advice
 
-HealthExporter is a data export utility. It does not provide medical advice, diagnosis, or treatment recommendations. The exported data is a reflection of what is stored in Apple HealthKit and should not be used as a substitute for professional medical judgment. Always consult a qualified healthcare provider with questions about your health.
+HealthExporterCSV is a data export utility. It does not provide medical advice, diagnosis, or treatment recommendations. The exported data is a reflection of what is stored in Apple HealthKit and should not be used as a substitute for professional medical judgment. Always consult a qualified healthcare provider with questions about your health.
 
 ### Limitation of Liability
 
@@ -212,4 +212,4 @@ In no event shall the developer be liable for any claim, damages, or other liabi
 
 ### Data Accuracy
 
-HealthExporter exports data as recorded in Apple HealthKit. The developer makes no guarantees about the accuracy, completeness, or reliability of the underlying health data or the exported CSV files.
+HealthExporterCSV exports data as recorded in Apple HealthKit. The developer makes no guarantees about the accuracy, completeness, or reliability of the underlying health data or the exported CSV files.

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -28,7 +28,7 @@ You control exactly which data types to share through the Apple Health permissio
 Your health data is used solely to generate CSV export files on your device. Specifically:
 
 - Data is read from HealthKit only when you initiate an export.
-- The CSV file is generated in memory and presented via the system file picker.
+- The CSV file is generated in memory and presented through the system file picker.
 - Health data is cleared from app memory immediately after export.
 - No health data is stored persistently by the app.
 


### PR DESCRIPTION
## Summary
- align the in-app privacy policy with the shipped app name `HealthExporterCSV`
- align README and web privacy policy wording with the current file-picker export flow
- remove stale internal doc references to the old Save/Share flow

## Notes
- this is a documentation and copy consistency pass only
- no product behavior changed