### PR TITLE
Restore HealthKit update purpose string

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,7 @@ Do not commit real secrets; use `Secrets.plist.example` as the template. Keep He
 Required capabilities and configuration:
 - HealthKit is always required.
 - Clinical Health Records is required for A1C export.
-- Usage descriptions are set via build settings: `NSHealthShareUsageDescription` and `NSHealthClinicalHealthRecordsShareUsageDescription`.
+- Usage descriptions are set via build settings: `NSHealthShareUsageDescription`, `NSHealthClinicalHealthRecordsShareUsageDescription`, and `NSHealthUpdateUsageDescription`.
+- Keep `NSHealthUpdateUsageDescription` in the app target even though the production export flow is read-only. `HealthKitManager.generateTestData()` calls `healthStore.save(...)` inside simulator-only code, and App Store validation still expects the write-purpose string to exist when that API is referenced.
 
 HealthKit requires a physical device for full verification. The simulator has limited support; use the simulator-only test data generator for UI development when needed.

--- a/HealthExporter.xcodeproj/project.pbxproj
+++ b/HealthExporter.xcodeproj/project.pbxproj
@@ -357,6 +357,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = "HealthExporterCSV";
 				INFOPLIST_KEY_NSHealthClinicalHealthRecordsShareUsageDescription = "HealthExporter needs access to your clinical health records to export your Hemoglobin A1C results.";
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "HealthExporter needs access to your health data to export your weight, steps, and glucose measurements.";
+				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "HealthExporterCSV may write sample HealthKit data during simulator-only development and testing. The production app does not write your health data.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -394,6 +395,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = "HealthExporterCSV";
 				INFOPLIST_KEY_NSHealthClinicalHealthRecordsShareUsageDescription = "HealthExporter needs access to your clinical health records to export your Hemoglobin A1C results.";
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "HealthExporter needs access to your health data to export your weight, steps, and glucose measurements.";
+				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "HealthExporterCSV may write sample HealthKit data during simulator-only development and testing. The production app does not write your health data.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;


### PR DESCRIPTION
## Summary
- restore `NSHealthUpdateUsageDescription` in the app target build settings
- use a purpose string that accurately describes the simulator-only HealthKit write path
- document in `AGENTS.md` why this key must not be removed again

## Why
App Store upload validation flags the app because the target still references `healthStore.save(...)` in simulator-only test-data code, even though the production export flow is read-only.

## Notes
- this does not change production behavior
- the app still requests read authorization with `toShare: Set()` in the normal export flow