### PR TITLE
Auto-bump patch version on every merged PR

### DIFF
--- a/.github/workflows/bump-build-number.yml
+++ b/.github/workflows/bump-build-number.yml
@@ -21,23 +21,36 @@ jobs:
           ref: main
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Bump build number
+      - name: Bump build number and patch version
         run: |
           FILE="HealthExporter.xcodeproj/project.pbxproj"
-          # Read current build number (first occurrence)
+
+          # Bump CURRENT_PROJECT_VERSION (build number)
           CURRENT=$(grep -m1 'CURRENT_PROJECT_VERSION' "$FILE" | sed 's/[^0-9]//g')
           NEXT=$((CURRENT + 1))
           echo "Bumping build number: $CURRENT -> $NEXT"
           sed -i "s/CURRENT_PROJECT_VERSION = $CURRENT;/CURRENT_PROJECT_VERSION = $NEXT;/g" "$FILE"
-          # Verify all occurrences were updated
           grep 'CURRENT_PROJECT_VERSION' "$FILE"
+
+          # Bump MARKETING_VERSION patch component (e.g. 2.4.6 -> 2.4.7)
+          MARKETING=$(grep -m1 'MARKETING_VERSION' "$FILE" | sed 's/.*= //;s/;.*//')
+          MAJOR=$(echo "$MARKETING" | cut -d. -f1)
+          MINOR=$(echo "$MARKETING" | cut -d. -f2)
+          PATCH=$(echo "$MARKETING" | cut -d. -f3)
+          NEW_PATCH=$((PATCH + 1))
+          NEW_VERSION="$MAJOR.$MINOR.$NEW_PATCH"
+          echo "Bumping marketing version: $MARKETING -> $NEW_VERSION"
+          sed -i "s/MARKETING_VERSION = $MARKETING;/MARKETING_VERSION = $NEW_VERSION;/g" "$FILE"
+          grep 'MARKETING_VERSION' "$FILE"
 
       - name: Commit and push
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add HealthExporter.xcodeproj/project.pbxproj
-          git commit -m "Bump build number to $(grep -m1 'CURRENT_PROJECT_VERSION' HealthExporter.xcodeproj/project.pbxproj | sed 's/[^0-9]//g') [skip ci]"
+          BUILD=$(grep -m1 'CURRENT_PROJECT_VERSION' HealthExporter.xcodeproj/project.pbxproj | sed 's/[^0-9]//g')
+          VERSION=$(grep -m1 'MARKETING_VERSION' HealthExporter.xcodeproj/project.pbxproj | sed 's/.*= //;s/;.*//')
+          git commit -m "Bump version to $VERSION (build $BUILD) [skip ci]"
           git push
 
       - name: Tag release

--- a/.github/workflows/bump-build-number.yml
+++ b/.github/workflows/bump-build-number.yml
@@ -39,3 +39,16 @@ jobs:
           git add HealthExporter.xcodeproj/project.pbxproj
           git commit -m "Bump build number to $(grep -m1 'CURRENT_PROJECT_VERSION' HealthExporter.xcodeproj/project.pbxproj | sed 's/[^0-9]//g') [skip ci]"
           git push
+
+      - name: Tag release
+        run: |
+          FILE="HealthExporter.xcodeproj/project.pbxproj"
+          TAG="v$(grep -m1 'MARKETING_VERSION' "$FILE" | sed 's/[^0-9.]//g')"
+
+          if git ls-remote --tags origin "$TAG" | grep -q "$TAG"; then
+            echo "Tag $TAG already exists"
+            exit 0
+          fi
+
+          git tag -a "$TAG" -m "$TAG"
+          git push origin "$TAG"

--- a/HealthExporter.xcodeproj/project.pbxproj
+++ b/HealthExporter.xcodeproj/project.pbxproj
@@ -365,7 +365,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.4.5;
+				MARKETING_VERSION = 2.4.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.evanhoffman.HealthExporter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -403,7 +403,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.4.5;
+				MARKETING_VERSION = 2.4.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.evanhoffman.HealthExporter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -424,7 +424,7 @@
 				CURRENT_PROJECT_VERSION = 38;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 2.4.5;
+				MARKETING_VERSION = 2.4.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.evanhoffman.HealthExporterTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
@@ -445,7 +445,7 @@
 				CURRENT_PROJECT_VERSION = 38;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 2.4.5;
+				MARKETING_VERSION = 2.4.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.evanhoffman.HealthExporterTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;

--- a/docs/app-store-review.md
+++ b/docs/app-store-review.md
@@ -3,9 +3,9 @@
 **Date:** 2026-03-18
 **Bundle ID:** `com.evanhoffman.HealthExporter`
 **Platform:** iOS 26+, iPhone
-**Version:** 2.4.5
+**Version:** 2.4.6
 
-This note tracks the current App Store review posture for the `2.4.5` submission and the cleanup items worth resolving before the next upload.
+This note tracks the current App Store review posture for the `2.4.6` submission and the cleanup items worth resolving before the next upload.
 
 ## Confirmed
 


### PR DESCRIPTION
## Summary
- Updates the "Bump Build Number" CI workflow to also increment the `MARKETING_VERSION` patch component on every merged PR (e.g., 2.4.6 → 2.4.7)
- Commit message now includes both version and build number
- The tag step already picks up the new marketing version, so releases will reflect the bumped patch

## Test plan
- [ ] Merge a test PR to main and verify the bot commit bumps both `CURRENT_PROJECT_VERSION` and `MARKETING_VERSION`
- [ ] Verify the created tag matches the new marketing version (e.g., `v2.4.7`)
- [ ] Verify the publish-release workflow triggers and creates a GitHub release
