### PR TITLE
Add self-hosted Mac TestFlight release pipeline

### DIFF
--- a/.github/workflows/release-testflight.yml
+++ b/.github/workflows/release-testflight.yml
@@ -1,0 +1,188 @@
+name: TestFlight Upload
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag or commit SHA to build (defaults to current ref)"
+        required: false
+  schedule:
+    # 13:00 UTC is 9am Eastern during daylight time.
+    - cron: "0 13 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: testflight-upload-${{ github.event.inputs.ref || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  upload:
+    name: Test, archive, and upload to TestFlight
+    runs-on: [self-hosted, macOS, ARM64]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+          fetch-depth: 0
+
+      - name: Check for daily changes
+        id: daily_changes
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DAILY_CHANGE_WINDOW: "24 hours ago"
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" != "schedule" ]; then
+            echo "Manual run; proceeding with TestFlight upload."
+            echo "should_upload=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          commit_count="$(git rev-list --count HEAD --since="$DAILY_CHANGE_WINDOW")"
+          if [ "$commit_count" -gt 0 ]; then
+            echo "Found $commit_count commit(s) in the last 24 hours; proceeding with TestFlight upload."
+            echo "should_upload=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No commits in the last 24 hours; skipping TestFlight upload."
+            echo "should_upload=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Report Xcode and reset CoreSimulator
+        if: ${{ steps.daily_changes.outputs.should_upload == 'true' }}
+        run: |
+          # The self-hosted runner's admin manages which Xcode is
+          # installed and xcode-select'd; don't use setup-xcode to
+          # flip versions, because a newer Xcode on disk whose iOS
+          # simulator runtime isn't installed will break tests.
+          xcode-select -p
+          xcodebuild -version
+          # When Xcode is upgraded between jobs the user-domain
+          # CoreSimulator daemon can keep running with the old framework
+          # and every simctl/xcodebuild call fails with "CoreSimulator
+          # is out of date". Kickstart the agent so it reloads against
+          # the currently-selected Xcode's framework.
+          launchctl kickstart -k "gui/$(id -u)/com.apple.CoreSimulator.CoreSimulatorService" || true
+          for _ in {1..10}; do
+            if xcrun simctl list devicetypes >/dev/null 2>&1; then
+              break
+            fi
+            sleep 1
+          done
+
+      - name: Run iOS tests
+        if: ${{ steps.daily_changes.outputs.should_upload == 'true' }}
+        run: |
+          set -euo pipefail
+          DEVICE_TYPE_ID=$(
+            xcrun simctl list devicetypes -j | /usr/bin/python3 -c "import json, sys; data = json.load(sys.stdin).get('devicetypes', []); preferred = next((d for d in data if d.get('name') == 'iPhone 16 Pro'), None); iphone = preferred or next((d for d in data if d.get('name', '').startswith('iPhone')), None); print(iphone['identifier'] if iphone else (_ for _ in ()).throw(SystemExit('No iPhone simulator device type available')))"
+          )
+          RUNTIME_ID=$(
+            xcrun simctl list runtimes available -j | /usr/bin/python3 -c "import json, sys; runtimes = [runtime for runtime in json.load(sys.stdin).get('runtimes', []) if runtime.get('isAvailable') and runtime.get('identifier', '').startswith('com.apple.CoreSimulator.SimRuntime.iOS-')]; runtimes.sort(key=lambda runtime: runtime['version']); print(runtimes[-1]['identifier'] if runtimes else (_ for _ in ()).throw(SystemExit('No iOS simulator runtime available')))"
+          )
+          SIMULATOR_ID=$(xcrun simctl create "HealthExporter TestFlight CI" "$DEVICE_TYPE_ID" "$RUNTIME_ID")
+          trap 'xcrun simctl delete "$SIMULATOR_ID"' EXIT
+          xcrun simctl boot "$SIMULATOR_ID"
+          xcrun simctl bootstatus "$SIMULATOR_ID" -b
+          xcodebuild test \
+            -project HealthExporter.xcodeproj \
+            -scheme HealthExporter \
+            -destination "id=$SIMULATOR_ID" \
+            -resultBundlePath "$RUNNER_TEMP/TestFlightTestResults"
+
+      - name: Unlock signing keychain
+        if: ${{ steps.daily_changes.outputs.should_upload == 'true' }}
+        env:
+          MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN="$HOME/Library/Keychains/login.keychain-db"
+          if [ ! -f "$KEYCHAIN" ]; then
+            echo "::error::Login keychain not found at $KEYCHAIN"
+            exit 1
+          fi
+          security unlock-keychain -p "$MACOS_KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          # Keep the keychain unlocked for the duration of the job; default
+          # locks on sleep or after a short timeout, which can break long builds.
+          security set-keychain-settings -lut 7200 "$KEYCHAIN"
+
+      - name: Stage App Store Connect API key
+        if: ${{ steps.daily_changes.outputs.should_upload == 'true' }}
+        env:
+          ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
+          ASC_API_KEY_P8: ${{ secrets.ASC_API_KEY_P8 }}
+        run: |
+          set -euo pipefail
+          KEY_DIR="$RUNNER_TEMP/asc_private_keys"
+          mkdir -p "$KEY_DIR"
+          KEY_PATH="$KEY_DIR/AuthKey_${ASC_API_KEY_ID}.p8"
+          printf '%s' "$ASC_API_KEY_P8" > "$KEY_PATH"
+          chmod 600 "$KEY_PATH"
+          echo "ASC_KEY_DIR=$KEY_DIR" >> "$GITHUB_ENV"
+          echo "ASC_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
+
+      - name: Archive
+        if: ${{ steps.daily_changes.outputs.should_upload == 'true' }}
+        env:
+          ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
+          ASC_API_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          xcodebuild archive \
+            -project HealthExporter.xcodeproj \
+            -scheme HealthExporter \
+            -configuration Release \
+            -destination 'generic/platform=iOS' \
+            -archivePath "$RUNNER_TEMP/HealthExporter.xcarchive" \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath "$ASC_KEY_PATH" \
+            -authenticationKeyID "$ASC_API_KEY_ID" \
+            -authenticationKeyIssuerID "$ASC_API_ISSUER_ID" \
+            CODE_SIGN_STYLE=Automatic \
+            DEVELOPMENT_TEAM=94S5PZTVPY
+
+      - name: Export IPA
+        if: ${{ steps.daily_changes.outputs.should_upload == 'true' }}
+        env:
+          ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
+          ASC_API_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          xcodebuild -exportArchive \
+            -archivePath "$RUNNER_TEMP/HealthExporter.xcarchive" \
+            -exportOptionsPlist ci/ExportOptions.plist \
+            -exportPath "$RUNNER_TEMP/export" \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath "$ASC_KEY_PATH" \
+            -authenticationKeyID "$ASC_API_KEY_ID" \
+            -authenticationKeyIssuerID "$ASC_API_ISSUER_ID"
+
+      - name: Upload IPA for Internal TestFlight
+        if: ${{ steps.daily_changes.outputs.should_upload == 'true' }}
+        env:
+          ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
+          ASC_API_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}
+          API_PRIVATE_KEYS_DIR: ${{ env.ASC_KEY_DIR }}
+        run: |
+          set -euo pipefail
+          IPA_PATH=$(/usr/bin/find "$RUNNER_TEMP/export" -maxdepth 2 -name "*.ipa" | head -n 1)
+          if [ -z "$IPA_PATH" ]; then
+            echo "::error::No .ipa produced by exportArchive"
+            exit 1
+          fi
+          echo "Uploading $IPA_PATH"
+          xcrun altool --upload-app \
+            --type ios \
+            --file "$IPA_PATH" \
+            --apiKey "$ASC_API_KEY_ID" \
+            --apiIssuer "$ASC_API_ISSUER_ID"
+
+      - name: Clean up API key
+        if: ${{ always() && steps.daily_changes.outputs.should_upload == 'true' }}
+        run: |
+          if [ -n "${ASC_KEY_DIR:-}" ] && [ -d "$ASC_KEY_DIR" ]; then
+            rm -rf "$ASC_KEY_DIR"
+          fi

--- a/README.md
+++ b/README.md
@@ -106,6 +106,30 @@ Unit tests run automatically in GitHub Actions CI on every push and PR. See [doc
 
 Hemoglobin A1C export has been **verified working end-to-end** on a physical device with Clinical Health Records enabled. See [docs/a1c/](docs/a1c/) for implementation details.
 
+## Releases
+
+Three GitHub Actions workflows handle the release pipeline:
+
+| Workflow | Trigger | Runner | What it does |
+|----------|---------|--------|--------------|
+| `.github/workflows/bump-build-number.yml` | PR merge to `main` | `ubuntu-latest` | Increments `CURRENT_PROJECT_VERSION` and the `MARKETING_VERSION` patch component, commits the bump, and pushes a `vX.Y.Z` tag |
+| `.github/workflows/publish-release.yml` | `v*` tag push | `ubuntu-latest` | Creates the GitHub release with auto-generated notes |
+| `.github/workflows/release-testflight.yml` | Manual dispatch + daily 13:00 UTC schedule | `[self-hosted, macOS, ARM64]` (`MacMiniM4_01`) | Tests, archives, exports a signed IPA via [`ci/ExportOptions.plist`](ci/ExportOptions.plist), and uploads it to internal TestFlight |
+
+Manual TestFlight upload for the current `main`:
+
+```sh
+gh workflow run release-testflight.yml --repo evanwtf/HealthExporter
+```
+
+Upload a specific tag or commit:
+
+```sh
+gh workflow run release-testflight.yml --repo evanwtf/HealthExporter -f ref=vX.Y.Z
+```
+
+The TestFlight workflow requires the `MACOS_KEYCHAIN_PASSWORD`, `ASC_API_KEY_ID`, `ASC_API_ISSUER_ID`, and `ASC_API_KEY_P8` secrets, plus a `HealthExporter App Store` provisioning profile installed on the runner with HealthKit and Clinical Health Records capabilities. See [docs/macos-runner-recovery.md](docs/macos-runner-recovery.md) when signing or runner state drifts.
+
 ## Project Structure
 
 ```
@@ -142,7 +166,8 @@ HealthExporter/
 │   └── a1c/
 │       ├── QUICK_REFERENCE.md
 │       └── IMPLEMENTATION_GUIDE.md
-├── .github/workflows/ios-tests.yml
+├── .github/workflows/         # ios-tests, bump-build-number, publish-release, release-testflight
+├── ci/ExportOptions.plist
 └── README.md
 ```
 

--- a/ci/ExportOptions.plist
+++ b/ci/ExportOptions.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>method</key>
+	<string>app-store-connect</string>
+	<key>teamID</key>
+	<string>94S5PZTVPY</string>
+	<key>signingStyle</key>
+	<string>manual</string>
+	<key>provisioningProfiles</key>
+	<dict>
+		<key>com.evanhoffman.HealthExporter</key>
+		<string>HealthExporter App Store</string>
+	</dict>
+	<key>destination</key>
+	<string>export</string>
+	<key>uploadSymbols</key>
+	<true/>
+	<key>stripSwiftSymbols</key>
+	<true/>
+	<key>generateAppStoreInformation</key>
+	<false/>
+</dict>
+</plist>

--- a/docs/macos-runner-recovery.md
+++ b/docs/macos-runner-recovery.md
@@ -1,0 +1,332 @@
+# macOS Self-Hosted Runner Recovery — How-To
+
+A recovery runbook for the `MacMiniM4_01` self-hosted GitHub Actions runner that
+builds and uploads TestFlight releases.
+
+Use this document when the `release-testflight.yml` workflow starts failing in
+ways consistent with a missing private key, an invalid provisioning profile, a
+broken keychain ACL, or a stuck runner process. The most common trigger is a
+macOS account password reset on the Mac mini (especially a reset done via
+Recovery / Apple ID, where you did not know the old password), but the same
+recovery steps apply whenever signing material on the runner gets lost.
+
+## Contents
+
+1. [Symptoms — when to use this doc](#1-symptoms--when-to-use-this-doc)
+2. [Background — what a password reset breaks](#2-background--what-a-password-reset-breaks)
+3. [Inventory the damage](#3-inventory-the-damage)
+4. [Recovery procedure](#4-recovery-procedure)
+5. [Verify end-to-end](#5-verify-end-to-end)
+6. [Prevention for next time](#6-prevention-for-next-time)
+7. [Reference — workflow, secrets, paths](#7-reference--workflow-secrets-paths)
+
+---
+
+## 1. Symptoms — when to use this doc
+
+Any of the following in a `release-testflight.yml` run usually points here:
+
+- The `Unlock signing keychain` step fails with
+  `security: SecKeychainUnlock /Users/evanhoffman/Library/Keychains/login.keychain-db:
+  The user name or passphrase you entered is not correct.` and the job exits 51
+  before touching anything else. The `MACOS_KEYCHAIN_PASSWORD` GitHub secret no
+  longer matches what the local keychain expects — see Section 4.1.
+- The `Archive` step fails with
+  `error: Revoke certificate: Your account already has an Apple Development
+  signing certificate for this machine, but its private key is not installed
+  in your keychain.`
+- The `Archive` step fails with
+  `error: No signing certificate "iOS Development" found: No "iOS Development"
+  signing certificate matching team ID "94S5PZTVPY" with a private key was
+  found.`
+- The `Export IPA` step fails with
+  `error: exportArchive No signing certificate "iOS Distribution" found`.
+- The `Export IPA` step fails with `errSecInternalComponent` from `codesign`
+  while re-signing `HealthExporter.app`.
+- A queued job stays queued for many minutes with `MacMiniM4_01` showing
+  "Offline" in https://github.com/organizations/evanwtf/settings/actions/runners
+  even though `Runner.Listener` is in `ps`.
+
+If you only see one symptom, you may only need part of this runbook. Read
+Section 3 to scope the damage before running the full procedure.
+
+## 2. Background — what a password reset breaks
+
+The TestFlight workflow depends on three independent things on the runner:
+
+1. The `login.keychain-db` keychain file, unlockable with the password stored
+   in the `MACOS_KEYCHAIN_PASSWORD` GitHub secret.
+2. The signing certificates **and their private keys** inside that keychain
+   (`Apple Development` and `Apple Distribution`, both team `94S5PZTVPY`).
+3. The named provisioning profile on disk in
+   `~/Library/Developer/Xcode/UserData/Provisioning Profiles/`:
+   `HealthExporter App Store`. This is required because
+   [`ci/ExportOptions.plist`](../ci/ExportOptions.plist) uses manual signing
+   with that exact profile name. Manual signing matters here because the
+   profile must include both HealthKit and Clinical Health Records
+   capabilities — automatic signing has been observed to return a stale
+   profile missing one of them, which silently produces an IPA that the App
+   Store Connect ingest rejects.
+
+A macOS account password reset can break each of these in a different way:
+
+- **Login keychain unlock password.** A normal "change password" from System
+  Settings keeps the keychain unlock password in sync with the new account
+  password. A Recovery / Apple ID reset does **not** — the keychain unlock
+  password stays at the *old* macOS password. The `MACOS_KEYCHAIN_PASSWORD`
+  GitHub secret tracks the keychain unlock password, not the macOS account
+  password, so a Recovery reset typically leaves the secret valid.
+- **Private keys.** iCloud Keychain syncs certificates across devices but
+  **does not** sync the matching private keys (they are non-exportable by
+  design). After a reset, the cert may come back via iCloud while the private
+  key is permanently gone. `security find-identity -v -p codesigning` will
+  return `0 valid identities found`.
+- **Provisioning profiles.** Profile files in `~/Library/Developer/Xcode/...`
+  are not encrypted by the keychain, so they usually survive on disk. But
+  every profile binds to a specific cert, so once the matching cert is gone
+  (or you revoke it on developer.apple.com), the profile is dead too.
+- **Keychain partition list ACL.** New private keys imported into a keychain
+  by Xcode → Manage Certificates have a restrictive default ACL that forces
+  a GUI confirmation the first time a non-Xcode tool (notably `codesign` and
+  `productbuild`) tries to use them. CI has no GUI, so the call fails with
+  `errSecInternalComponent`.
+- **Runner process.** The launchd-managed `Runner.Listener` can survive the
+  reset but lose its broker connection and stop polling. The process is alive
+  in `ps`, but the org's runner page shows it as Offline.
+
+## 3. Inventory the damage
+
+Run these on the Mac mini to figure out what is actually broken before doing
+any cert work:
+
+```sh
+# 1. Is the runner process running?
+ps aux | grep Runner.Listener | grep -v grep
+
+# 2. Does the keychain still unlock?
+security unlock-keychain ~/Library/Keychains/login.keychain-db
+# (Type the OLD macOS password first; that is what the keychain remembers.)
+
+# 3. Do we have any usable signing identities?
+security find-identity -v -p codesigning
+
+# 4. What named provisioning profiles are on disk?
+for f in ~/Library/Developer/Xcode/UserData/Provisioning\ Profiles/*.mobileprovision; do
+  printf '%s  ' "$(basename "$f")"
+  security cms -D -i "$f" 2>/dev/null | plutil -extract Name raw -o - -
+done
+```
+
+Interpreting the output:
+
+- (1) If the process is gone or shows Offline in the org runners page, jump
+  to Section 4.6 — restart the runner. To see why it lost the connection in
+  the first place, check the most recent diag log:
+
+  ```sh
+  ls -lt ~/actions-runner/_diag/Runner_*.log | head -1
+  tail -50 "$(ls -t ~/actions-runner/_diag/Runner_*.log | head -1)"
+  ```
+- (2) If `unlock-keychain` errors, the keychain file got replaced or the
+  password really did change. Try the new macOS password; if that works,
+  rotate the GitHub secret as described in Section 4.1.
+- (3) If `0 valid identities found`, you have lost both private keys and need
+  to do the full cert+profile recovery (Sections 4.2, 4.3, 4.4).
+- (4) If `HealthExporter App Store` appears more than once, the duplicates
+  are stale and need to be deleted (Section 4.4).
+
+## 4. Recovery procedure
+
+**Order of operations** — the full sequence assuming both private keys are
+gone and the named profile is stale (the worst case, and the case the
+runbook was first written from):
+
+| Step | What you do | Where |
+| ---- | ----------- | ----- |
+| 4.1 | Rotate `MACOS_KEYCHAIN_PASSWORD` if the keychain unlock password changed | Local + `gh` |
+| 4.2 | Revoke the orphaned Apple Development and Apple Distribution certs | developer.apple.com → Certificates |
+| 4.3 | Re-create the Apple Distribution cert and private key via Xcode → Manage Certificates | Mac mini (GUI) |
+| 4.4 | Re-issue the `HealthExporter App Store` profile against the new cert, install it, delete stale duplicates | developer.apple.com → Profiles, then Mac mini |
+| 4.5 | Set the keychain partition list so `codesign` can use the new keys without a GUI prompt | Mac mini shell |
+| 4.6 | Restart the runner via `~/actions-runner/svc.sh` if it is stuck | Mac mini shell |
+| 5   | Dispatch the workflow and watch it green-light | `gh` |
+
+Do these steps in order. Skip any that are already healthy per Section 3 (for
+example, if `security find-identity -v -p codesigning` already lists both
+identities, skip 4.2 and 4.3).
+
+### 4.1. Rotate `MACOS_KEYCHAIN_PASSWORD` if and only if the unlock password changed
+
+If `security unlock-keychain` only succeeds with the **new** macOS password
+(i.e. the keychain unlock password was migrated by a normal "change password"
+flow), update the GitHub secret to match:
+
+```sh
+gh secret set MACOS_KEYCHAIN_PASSWORD --repo evanwtf/HealthExporter
+```
+
+Otherwise — and this is the common case after a Recovery / Apple ID reset —
+**do not touch this secret**. The keychain still unlocks with the old password
+that the secret already holds.
+
+### 4.2. Revoke the orphaned certificates
+
+Go to https://developer.apple.com/account/resources/certificates/list. Revoke
+every Apple Development and Apple Distribution certificate associated with
+this Mac mini whose private key is missing locally. These are the ones whose
+expiration dates match the runner's original provisioning date (and any
+re-issues since). Do **not** revoke:
+
+- The `Distribution Managed` cert. That one is Apple-managed via the App
+  Store Connect API key and rotates on its own.
+- Any cert that belongs to a different machine (e.g. a development cert tied
+  to your laptop). Verify by running `security find-identity -v -p codesigning`
+  on that other machine — if it lists the cert, leave it alone.
+
+### 4.3. Re-create the certificates
+
+On the Mac mini, open Xcode → **Settings → Accounts** → select your Apple ID →
+**Manage Certificates…** → "+" → choose **Apple Distribution**. Xcode
+generates a CSR, submits it via the App Store Connect API, downloads the new
+cert, and imports the private key into `login.keychain-db` in one shot.
+
+You do not need to do this for Apple Development: the TestFlight workflow
+already passes `-allowProvisioningUpdates -authenticationKeyPath …` to
+`xcodebuild`, which re-creates the Development cert via the App Store Connect
+API key automatically on the next CI run.
+
+Verify:
+
+```sh
+security find-identity -v -p codesigning
+```
+
+Expect two valid identities for team `94S5PZTVPY`: `Apple Development` and
+`Apple Distribution`.
+
+### 4.4. Re-issue and reinstall the manual provisioning profile
+
+`HealthExporter App Store` is bound to the now-revoked Distribution cert and
+needs to be re-issued against the new one. The profile must include both
+**HealthKit** and **HealthKit / Clinical Health Records** capabilities —
+double-check both checkboxes are ticked on the App ID
+`com.evanhoffman.HealthExporter` before re-issuing.
+
+1. https://developer.apple.com/account/resources/profiles/list — click
+   **Edit** on `HealthExporter App Store`, re-select the new
+   `Apple Distribution: EVAN DAVID HOFFMAN (94S5PZTVPY)` cert, click
+   **Save**, then **Download**.
+2. Double-click the downloaded `.mobileprovision` to install it. macOS places
+   the file in `~/Library/Developer/Xcode/UserData/Provisioning Profiles/`
+   with a fresh UUID.
+3. Delete any stale duplicates (older files with the same `Name` that still
+   reference the revoked cert). Identify them by re-running the loop from
+   Section 3 — if `HealthExporter App Store` appears more than once, the
+   older UUID is stale:
+
+   ```sh
+   rm ~/Library/Developer/Xcode/UserData/Provisioning\ Profiles/<old-uuid>.mobileprovision
+   ```
+
+   Leave the auto-managed `iOS Team Provisioning Profile: …` files alone;
+   they have different names and won't be picked up by manual signing.
+
+### 4.5. Fix the keychain partition list
+
+New private keys added by Xcode → Manage Certificates start with a
+restrictive ACL that blocks `codesign` from CI. Open the gate once for every
+key in the login keychain:
+
+```sh
+security set-key-partition-list \
+  -S apple-tool:,apple:,codesign: \
+  -s \
+  -k '<keychain-unlock-password>' \
+  ~/Library/Keychains/login.keychain-db
+```
+
+The command dumps the updated attributes of each key it modifies — that
+verbose output is normal, not an error. If macOS pops a GUI confirmation
+dialog the first time you run it, click **Always Allow**.
+
+### 4.6. Restart the runner if it is stuck
+
+If `Runner.Listener` is alive in `ps` but the org runner page shows the
+runner Offline (or queued jobs sit unpicked), bounce the service:
+
+```sh
+cd ~/actions-runner
+./svc.sh stop
+./svc.sh start
+./svc.sh status
+```
+
+After a few seconds the runner page should flip to **Idle** and any queued
+job should start.
+
+## 5. Verify end-to-end
+
+Trigger the workflow and watch it green-light:
+
+```sh
+gh workflow run release-testflight.yml --repo evanwtf/HealthExporter
+gh run watch "$(gh run list --repo evanwtf/HealthExporter \
+  --workflow=release-testflight.yml --limit 1 --json databaseId \
+  --jq '.[0].databaseId')" --repo evanwtf/HealthExporter
+```
+
+Steps to look at, in order: `Run iOS tests` → `Unlock signing keychain` →
+`Archive` → `Export IPA` → `Upload IPA for Internal TestFlight`. If all five
+go green the runner is fully recovered. End-to-end runtime is normally
+~2–3 minutes when nothing is wrong (no app code changes); a from-scratch
+build is closer to ~10–15 minutes.
+
+If `Export IPA` is the only step that fails with `errSecInternalComponent`,
+you skipped Section 4.5 — run it and re-dispatch.
+
+## 6. Prevention for next time
+
+Things that would have cut this incident from "an hour of cert rebuilding" to
+"a single import" if they had been in place beforehand:
+
+- **Export the signing identities to a `.p12` and store it somewhere safe**
+  (1Password, encrypted USB, Time Machine, an offline encrypted volume). In
+  Keychain Access, right-click the `Apple Distribution …` identity → **Export
+  Items…** → choose `.p12`, set a strong password, save. Repeat for the
+  Apple Development identity if you want to also bypass automatic
+  provisioning. Restoring is one `security import … -k login.keychain-db -P
+  <password> -T /usr/bin/codesign` away.
+- **Disable iCloud Keychain syncing of code-signing certificates** so a
+  cross-device iCloud event cannot resurrect a cert whose private key is
+  gone — that resurrected-but-keyless cert is exactly what makes the portal
+  refuse to re-issue automatically and forces the manual revoke step.
+- **Use a Mac-mini-specific local user password manager entry** so you do not
+  forget the macOS password in the first place. The keychain unlock password
+  stored in `MACOS_KEYCHAIN_PASSWORD` must match the local account password
+  if you ever change it from System Settings; if they drift, log in once via
+  GUI and follow the "Update Keychain Password" prompt so they re-sync.
+- **Consider `fastlane match`** as a longer-term solution. It stores
+  encrypted certs and profiles in a private git repository so any machine can
+  rehydrate the full signing state with one command. We do not use it today,
+  but if you find yourself rebuilding signing material more than once, it is
+  worth the migration.
+
+## 7. Reference — workflow, secrets, paths
+
+- Workflow: [`.github/workflows/release-testflight.yml`](../.github/workflows/release-testflight.yml)
+- Export options: [`ci/ExportOptions.plist`](../ci/ExportOptions.plist)
+  (`signingStyle = manual`, names the `HealthExporter App Store` profile)
+- Required secrets (org / repo level on `evanwtf/HealthExporter`):
+  - `MACOS_KEYCHAIN_PASSWORD` — login keychain unlock password
+  - `ASC_API_KEY_ID`, `ASC_API_ISSUER_ID`, `ASC_API_KEY_P8` — App Store Connect
+    API key
+- Provisioning profile directory:
+  `~/Library/Developer/Xcode/UserData/Provisioning Profiles/`
+  (modern Xcode location; the old `~/Library/MobileDevice/Provisioning Profiles/`
+  is still honored but no longer the default)
+- Runner directory: `~/actions-runner/` — `./svc.sh` controls the launchd
+  service; runner logs are in `~/actions-runner/_diag/Runner_*.log`
+- Apple Developer portal:
+  - Certificates: https://developer.apple.com/account/resources/certificates/list
+  - Profiles: https://developer.apple.com/account/resources/profiles/list
+- Org runners page: https://github.com/organizations/evanwtf/settings/actions/runners


### PR DESCRIPTION
## Summary
- Add `.github/workflows/release-testflight.yml` (adapted from StationCast) on `[self-hosted, macOS, ARM64]`: test → unlock keychain → archive → export IPA → `xcrun altool` upload. Triggered by manual dispatch (with optional `ref` input) or daily at 13:00 UTC, gated by a skip-if-no-commits check.
- Add `ci/ExportOptions.plist` for App Store Connect export: manual signing, team `94S5PZTVPY`, single bundle ID `com.evanhoffman.HealthExporter` → `HealthExporter App Store` profile.
- Add `docs/macos-runner-recovery.md` — HealthExporter-scoped clone of StationCast's recovery runbook covering keychain unlock failures, missing private keys, stale profiles, `errSecInternalComponent`, and offline runner state.
- Document the three-workflow release pipeline (`bump-build-number` → `publish-release` → `release-testflight`) in README.

Version-bump alignment with StationCast's semver-label flow (issue section 6) is intentionally deferred — orthogonal to enabling TestFlight uploads and worth its own issue if pursued.

Closes #103

## Test plan
- [ ] Confirm required secrets exist on `evanwtf/HealthExporter`: `MACOS_KEYCHAIN_PASSWORD`, `ASC_API_KEY_ID`, `ASC_API_ISSUER_ID`, `ASC_API_KEY_P8`
- [ ] Create `HealthExporter App Store` provisioning profile in App Store Connect for `com.evanhoffman.HealthExporter` with HealthKit and Clinical Health Records capabilities; install on `MacMiniM4_01`
- [ ] Manual dispatch: `gh workflow run release-testflight.yml`; confirm Run iOS tests → Unlock keychain → Archive → Export IPA → Upload IPA all go green
- [ ] Tagged build: `gh workflow run release-testflight.yml -f ref=vX.Y.Z`
- [ ] Confirm uploaded build appears in TestFlight internal group
