### PR TITLE
Add lab panels and vital exports

### DIFF
--- a/HealthExporter.xcodeproj/project.pbxproj
+++ b/HealthExporter.xcodeproj/project.pbxproj
@@ -353,7 +353,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = HealthExporter/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = HealthExporterCSV;
-				INFOPLIST_KEY_NSHealthClinicalHealthRecordsShareUsageDescription = "HealthExporter needs access to your clinical health records to export your Hemoglobin A1C results.";
+				INFOPLIST_KEY_NSHealthClinicalHealthRecordsShareUsageDescription = "HealthExporter needs access to your clinical health records to export selected lab results.";
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "HealthExporter needs access to your health data to export your weight, steps, and glucose measurements.";
 				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "HealthExporterCSV may write sample HealthKit data during simulator-only development and testing. The production app does not write your health data.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -391,7 +391,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = HealthExporter/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = HealthExporterCSV;
-				INFOPLIST_KEY_NSHealthClinicalHealthRecordsShareUsageDescription = "HealthExporter needs access to your clinical health records to export your Hemoglobin A1C results.";
+				INFOPLIST_KEY_NSHealthClinicalHealthRecordsShareUsageDescription = "HealthExporter needs access to your clinical health records to export selected lab results.";
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "HealthExporter needs access to your health data to export your weight, steps, and glucose measurements.";
 				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "HealthExporterCSV may write sample HealthKit data during simulator-only development and testing. The production app does not write your health data.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;

--- a/HealthExporter/HealthExporter/CSVGenerator.swift
+++ b/HealthExporter/HealthExporter/CSVGenerator.swift
@@ -89,6 +89,14 @@ class CSVGenerator {
         return "\(date),\(metric),\(value),\(sample.unit),\(source)\n"
     }
 
+    private static func vitalRow(for sample: HKQuantitySample, component: VitalMetricComponent, temperatureUnit: TemperatureUnit, dateFormatter: DateFormatter) -> String {
+        let date = dateFormatter.string(from: sample.startDate)
+        let source = csvEscape(sample.sourceRevision.source.name)
+        let result = component.valueAndUnit(from: sample.quantity, temperatureUnit: temperatureUnit)
+        let value = String(format: "%.\(component.valuePrecision)f", result.value)
+        return "\(date),\(component.displayName),\(value),\(result.unit),\(source)\n"
+    }
+
     // MARK: - Append methods (memory-efficient, sort in-place, write directly to string)
 
     static func appendWeightRows(to csv: inout String, samples: inout [HKQuantitySample], unit: WeightUnit, dateFormat: DateFormatOption = .yyyyMMddHHmmss, sortOrder: SortOrder = .ascending) {
@@ -123,12 +131,25 @@ class CSVGenerator {
         }
     }
 
-    static func makePreviewEstimate(weightSamples: [HKQuantitySample]?, stepsSamples: [HKQuantitySample]?, glucoseSamples: [GlucoseSampleMgDl]?, labResults: [LabResultSample]?, weightUnit: WeightUnit, dateFormat: DateFormatOption = .yyyyMMddHHmmss) -> ExportPreviewEstimate {
+    static func appendVitalRows(to csv: inout String, samplesByComponent: inout [VitalMetricComponent: [HKQuantitySample]], temperatureUnit: TemperatureUnit, dateFormat: DateFormatOption = .yyyyMMddHHmmss, sortOrder: SortOrder = .ascending) {
+        let dateFormatter = makeDateFormatter(for: dateFormat)
+        for component in VitalMetricComponent.allCases {
+            guard var samples = samplesByComponent[component] else { continue }
+            samplesByComponent[component] = nil
+            samples.sort { sortOrder == .ascending ? $0.startDate < $1.startDate : $0.startDate > $1.startDate }
+            for sample in samples {
+                csv.append(vitalRow(for: sample, component: component, temperatureUnit: temperatureUnit, dateFormatter: dateFormatter))
+            }
+        }
+    }
+
+    static func makePreviewEstimate(weightSamples: [HKQuantitySample]?, stepsSamples: [HKQuantitySample]?, glucoseSamples: [GlucoseSampleMgDl]?, labResults: [LabResultSample]?, vitalSamples: [VitalMetricComponent: [HKQuantitySample]]? = nil, weightUnit: WeightUnit, temperatureUnit: TemperatureUnit = .fahrenheit, dateFormat: DateFormatOption = .yyyyMMddHHmmss) -> ExportPreviewEstimate {
         let weightCount = weightSamples?.count ?? 0
         let stepsCount = stepsSamples?.count ?? 0
         let glucoseCount = glucoseSamples?.count ?? 0
         let labCount = labResults?.count ?? 0
-        let rowCount = weightCount + stepsCount + glucoseCount + labCount
+        let vitalCount = vitalSamples?.values.reduce(0) { $0 + $1.count } ?? 0
+        let rowCount = weightCount + stepsCount + glucoseCount + labCount + vitalCount
 
         let dateFormatter = makeDateFormatter(for: dateFormat)
         var estimatedByteCount = (csvHeader + "\n").utf8.count
@@ -157,6 +178,15 @@ class CSVGenerator {
             }
         }
 
+        if let samplesByComponent = vitalSamples {
+            for component in VitalMetricComponent.allCases {
+                guard let samples = samplesByComponent[component] else { continue }
+                for sample in samples {
+                    estimatedByteCount += vitalRow(for: sample, component: component, temperatureUnit: temperatureUnit, dateFormatter: dateFormatter).utf8.count
+                }
+            }
+        }
+
         return ExportPreviewEstimate(rowCount: rowCount, estimatedByteCount: estimatedByteCount)
     }
 
@@ -176,7 +206,7 @@ class CSVGenerator {
         return csv
     }
 
-    static func generateCombinedCSV(weightSamples: [HKQuantitySample]?, stepsSamples: [HKQuantitySample]?, glucoseSamples: [GlucoseSampleMgDl]?, labResults: [LabResultSample]?, weightUnit: WeightUnit, dateFormat: DateFormatOption = .yyyyMMddHHmmss, sortOrder: SortOrder = .ascending) -> String {
+    static func generateCombinedCSV(weightSamples: [HKQuantitySample]?, stepsSamples: [HKQuantitySample]?, glucoseSamples: [GlucoseSampleMgDl]?, labResults: [LabResultSample]?, vitalSamples: [VitalMetricComponent: [HKQuantitySample]]? = nil, weightUnit: WeightUnit, temperatureUnit: TemperatureUnit = .fahrenheit, dateFormat: DateFormatOption = .yyyyMMddHHmmss, sortOrder: SortOrder = .ascending) -> String {
         var csv = csvHeader + "\n"
 
         if var samples = weightSamples {
@@ -193,6 +223,10 @@ class CSVGenerator {
 
         if var samples = labResults {
             appendLabResultRows(to: &csv, samples: &samples, dateFormat: dateFormat, sortOrder: sortOrder)
+        }
+
+        if var samplesByComponent = vitalSamples {
+            appendVitalRows(to: &csv, samplesByComponent: &samplesByComponent, temperatureUnit: temperatureUnit, dateFormat: dateFormat, sortOrder: sortOrder)
         }
 
         return csv

--- a/HealthExporter/HealthExporter/DataSelectionView.swift
+++ b/HealthExporter/HealthExporter/DataSelectionView.swift
@@ -10,6 +10,7 @@ private struct PendingExportPayload {
     var stepsSamples: [HKQuantitySample]?
     var glucoseSamples: [GlucoseSampleMgDl]?
     var labResults: [LabResultSample]?
+    var vitalSamples: [VitalMetricComponent: [HKQuantitySample]]
 }
 
 struct DataSelectionView: View {
@@ -44,7 +45,8 @@ struct DataSelectionView: View {
         settings.exportWeight ||
         settings.exportSteps ||
         settings.exportGlucose ||
-        hasSelectedLabs
+        hasSelectedLabs ||
+        hasSelectedVitals
     }
 
     private var hasSelectedLabs: Bool {
@@ -58,46 +60,104 @@ struct DataSelectionView: View {
         )
     }
 
+    private var hasSelectedVitals: Bool {
+        !settings.selectedVitalMetrics.isEmpty
+    }
+
+    private var vitalComponentsToFetch: [VitalMetricComponent] {
+        VitalMetricComponent.allCases.filter { component in
+            settings.selectedVitalMetrics.contains { $0.components.contains(component) }
+        }
+    }
+
     private func updateExportEnabled() {
         exportEnabled = ExportLogic.isExportEnabled(
             exportWeight: settings.exportWeight,
             exportSteps: settings.exportSteps,
             exportGlucose: settings.exportGlucose,
             hasSelectedLabs: hasSelectedLabs,
+            hasSelectedVitals: hasSelectedVitals,
             dateRangeOption: selectedDateRangeOption,
             startDate: startDate,
             endDate: endDate
         )
     }
 
-    private func favoriteBinding(for loincCode: String) -> Binding<Bool> {
+    private func labSelectionBinding(for loincCode: String) -> Binding<Bool> {
         Binding(
-            get: { settings.favoriteLabCodes.contains(loincCode) },
+            get: {
+                if settings.favoriteLabCodes.contains(loincCode) {
+                    return true
+                }
+                guard let panel = LabMetricRegistry.metric(forLoincCode: loincCode)?.group else {
+                    return false
+                }
+                return settings.selectedLabPanels.contains(panel)
+            },
             set: { newValue in
                 if newValue {
                     settings.favoriteLabCodes.insert(loincCode)
                 } else {
+                    if let panel = LabMetricRegistry.metric(forLoincCode: loincCode)?.group,
+                       settings.selectedLabPanels.contains(panel) {
+                        let remainingCodes = LabMetricRegistry.metrics(in: panel)
+                            .map(\.loincCode)
+                            .filter { $0 != loincCode }
+                        settings.selectedLabPanels.remove(panel)
+                        settings.favoriteLabCodes.formUnion(remainingCodes)
+                    }
                     settings.favoriteLabCodes.remove(loincCode)
                 }
             }
         )
     }
 
-    private func panelBinding(for panel: LabPanel) -> Binding<Bool> {
+    private func labPanelSelectionBinding(for panel: LabPanel) -> Binding<Bool> {
         Binding(
-            get: { settings.selectedLabPanels.contains(panel) },
+            get: {
+                let codes = LabMetricRegistry.metrics(in: panel).map(\.loincCode)
+                return settings.selectedLabPanels.contains(panel) || (!codes.isEmpty && codes.allSatisfy { settings.favoriteLabCodes.contains($0) })
+            },
             set: { newValue in
+                let codes = LabMetricRegistry.metrics(in: panel).map(\.loincCode)
                 if newValue {
+                    settings.favoriteLabCodes.formUnion(codes)
                     settings.selectedLabPanels.insert(panel)
                 } else {
+                    settings.favoriteLabCodes.subtract(codes)
                     settings.selectedLabPanels.remove(panel)
                 }
             }
         )
     }
 
-    private var panelsWithMetrics: [LabPanel] {
-        LabPanel.allCases.filter { !LabMetricRegistry.metrics(in: $0).isEmpty }
+    private func vitalMetricBinding(for metric: VitalMetric) -> Binding<Bool> {
+        Binding(
+            get: { settings.selectedVitalMetrics.contains(metric) },
+            set: { newValue in
+                if newValue {
+                    settings.selectedVitalMetrics.insert(metric)
+                } else {
+                    settings.selectedVitalMetrics.remove(metric)
+                }
+            }
+        )
+    }
+
+    private func vitalSectionBinding() -> Binding<Bool> {
+        Binding(
+            get: {
+                let metrics = Set(VitalMetric.allCases)
+                return !metrics.isEmpty && metrics.isSubset(of: settings.selectedVitalMetrics)
+            },
+            set: { newValue in
+                if newValue {
+                    settings.selectedVitalMetrics.formUnion(VitalMetric.allCases)
+                } else {
+                    settings.selectedVitalMetrics.removeAll()
+                }
+            }
+        )
     }
 
     private func presentSaveSuccessConfirmation() {
@@ -131,168 +191,169 @@ struct DataSelectionView: View {
         saveSuccessDismissTask = nil
     }
 
+    private func labPanelSection(_ panel: LabPanel) -> some View {
+        let metrics = LabMetricRegistry.metrics(in: panel)
+        return VStack(alignment: .leading, spacing: 6) {
+            Toggle(isOn: labPanelSelectionBinding(for: panel)) {
+                Text(panel.displayName)
+                    .font(.headline)
+            }
+            .accessibilityIdentifier("panel_\(panel.rawValue)")
+
+            ForEach(metrics) { metric in
+                Toggle(isOn: labSelectionBinding(for: metric.loincCode)) {
+                    HStack(spacing: 4) {
+                        Text(metric.name)
+                        Image(systemName: "cross.case")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+                .padding(.leading, 12)
+                .accessibilityIdentifier("lab_\(metric.loincCode)")
+            }
+        }
+    }
+
+    private func vitalsSection() -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Toggle(isOn: vitalSectionBinding()) {
+                Text("Vitals")
+                    .font(.headline)
+            }
+            .accessibilityIdentifier("vitalsSectionToggle")
+
+            ForEach(VitalMetric.allCases) { metric in
+                Toggle(metric.displayName, isOn: vitalMetricBinding(for: metric))
+                    .padding(.leading, 12)
+                    .accessibilityIdentifier("vital_\(metric.rawValue)")
+            }
+        }
+    }
+
     var body: some View {
         ZStack {
-            VStack {
-                Text("Select Data to Export")
-                    .font(.largeTitle)
-                    .padding()
-
-                Toggle(isOn: $settings.exportWeight) {
-                    Text("Weight")
-                }
-                .padding(.horizontal)
-                .accessibilityIdentifier("weightToggle")
-
-                Toggle(isOn: $settings.exportSteps) {
-                    Text("Steps")
-                }
-                .padding(.horizontal)
-                .accessibilityIdentifier("stepsToggle")
-
-                Toggle(isOn: $settings.exportGlucose) {
-                    Text("Blood Glucose (mg/dL)")
-                }
-                .padding(.horizontal)
-                .accessibilityIdentifier("glucoseToggle")
-
-                if !LabMetricRegistry.all.isEmpty {
-                    VStack(alignment: .leading, spacing: 6) {
-                        Text("Lab Favorites")
-                            .font(.subheadline)
-                            .foregroundColor(.secondary)
-
-                        ForEach(LabMetricRegistry.all) { metric in
-                            HStack {
-                                HStack(spacing: 4) {
-                                    Text(metric.name)
-                                    Image(systemName: "cross.case")
-                                        .font(.caption)
-                                        .foregroundColor(.secondary)
-                                }
-                                Spacer()
-                                Toggle("", isOn: favoriteBinding(for: metric.loincCode))
-                                    .labelsHidden()
-                                    .accessibilityIdentifier("favorite_\(metric.loincCode)")
-                            }
+            VStack(spacing: 0) {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Toggle(isOn: $settings.exportWeight) {
+                            Text("Weight")
                         }
+                        .accessibilityIdentifier("weightToggle")
 
-                        if !panelsWithMetrics.isEmpty {
-                            Text("Lab Panels")
-                                .font(.subheadline)
-                                .foregroundColor(.secondary)
-                                .padding(.top, 4)
+                        Toggle(isOn: $settings.exportSteps) {
+                            Text("Steps")
+                        }
+                        .accessibilityIdentifier("stepsToggle")
 
-                            ForEach(panelsWithMetrics, id: \.self) { panel in
-                                Toggle(panel.displayName, isOn: panelBinding(for: panel))
-                                    .accessibilityIdentifier("panel_\(panel.rawValue)")
-                            }
+                        Toggle(isOn: $settings.exportGlucose) {
+                            Text("Blood Glucose (mg/dL)")
+                        }
+                        .accessibilityIdentifier("glucoseToggle")
+
+                        ForEach(LabPanel.allCases, id: \.self) { panel in
+                            labPanelSection(panel)
                         }
 
                         HStack(spacing: 4) {
                             Image(systemName: "cross.case")
                                 .font(.caption2)
                                 .foregroundColor(.secondary)
-                            Text("Requires access to Clinical Health Records")
+                            Text("Lab sections require access to Clinical Health Records")
                                 .font(.caption2)
                                 .foregroundColor(.secondary)
                         }
                         .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                    .padding(.horizontal)
-                }
 
-                Divider()
-                    .padding()
+                        vitalsSection()
 
-                Text("Date Range")
-                    .font(.headline)
-                    .padding(.horizontal)
+                        Divider()
+                            .padding(.vertical, 8)
 
-                Picker("Date Range", selection: $selectedDateRangeOption) {
-                    ForEach(DateRangeOption.allCases, id: \.self) { option in
-                        Text(option.displayName).tag(option)
-                    }
-                }
-                .pickerStyle(.segmented)
-                .padding()
-                .accessibilityIdentifier("dateRangePicker")
+                        Text("Date Range")
+                            .font(.headline)
+                            .frame(maxWidth: .infinity, alignment: .center)
 
-                // Last X Days Option
-                if selectedDateRangeOption == .lastXDays {
-                    VStack(spacing: 4) {
-                        Text("Days:")
-                            .font(.subheadline)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                        Picker("Days", selection: $settings.lastXDaysValue) {
-                            ForEach(DataSelectionView.dayOptions, id: \.self) { days in
-                                Text("\(days)").tag(days)
+                        Picker("Date Range", selection: $selectedDateRangeOption) {
+                            ForEach(DateRangeOption.allCases, id: \.self) { option in
+                                Text(option.displayName).tag(option)
                             }
                         }
-                        .pickerStyle(.wheel)
-                        .frame(height: 120)
-                        .accessibilityLabel("Number of days")
+                        .pickerStyle(.segmented)
+                        .accessibilityIdentifier("dateRangePicker")
 
-                        Text(DayRangeSummaryFormatter.summaryText(forDays: settings.lastXDaysValue, relativeTo: Date()))
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                    .padding(.horizontal)
-                }
+                        if selectedDateRangeOption == .lastXDays {
+                            VStack(spacing: 4) {
+                                Text("Days:")
+                                    .font(.subheadline)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                Picker("Days", selection: $settings.lastXDaysValue) {
+                                    ForEach(DataSelectionView.dayOptions, id: \.self) { days in
+                                        Text("\(days)").tag(days)
+                                    }
+                                }
+                                .pickerStyle(.wheel)
+                                .frame(height: 120)
+                                .accessibilityLabel("Number of days")
 
-                // Last X Records Option
-                if selectedDateRangeOption == .lastXRecords {
-                    VStack(spacing: 4) {
-                        Text("Records:")
-                            .font(.subheadline)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                        Picker("Records", selection: $settings.lastXRecordsValue) {
-                            ForEach(DataSelectionView.recordOptions, id: \.self) { records in
-                                Text("\(records)").tag(records)
+                                Text(DayRangeSummaryFormatter.summaryText(forDays: settings.lastXDaysValue, relativeTo: Date()))
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
                             }
                         }
-                        .pickerStyle(.wheel)
-                        .frame(height: 120)
-                        .accessibilityLabel("Number of records")
+
+                        if selectedDateRangeOption == .lastXRecords {
+                            VStack(spacing: 4) {
+                                Text("Records:")
+                                    .font(.subheadline)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                Picker("Records", selection: $settings.lastXRecordsValue) {
+                                    ForEach(DataSelectionView.recordOptions, id: \.self) { records in
+                                        Text("\(records)").tag(records)
+                                    }
+                                }
+                                .pickerStyle(.wheel)
+                                .frame(height: 120)
+                                .accessibilityLabel("Number of records")
+                            }
+                        }
+
+                        if selectedDateRangeOption == .specificDateRange {
+                            VStack(alignment: .leading, spacing: 12) {
+                                VStack(alignment: .leading) {
+                                    Text("Start Date")
+                                        .font(.subheadline)
+                                        .foregroundColor(.gray)
+                                    DatePicker("", selection: $startDate, displayedComponents: .date)
+                                        .datePickerStyle(.compact)
+                                }
+
+                                VStack(alignment: .leading) {
+                                    Text("End Date")
+                                        .font(.subheadline)
+                                        .foregroundColor(.gray)
+                                    DatePicker("", selection: $endDate, displayedComponents: .date)
+                                        .datePickerStyle(.compact)
+                                }
+                            }
+                        }
+
+                        if !hasSelectedMetric {
+                            Text("Please select at least one metric")
+                                .font(.caption)
+                                .foregroundColor(.red)
+                        }
+
+                        if selectedDateRangeOption == .specificDateRange && !isValidDateRange {
+                            Text("End date must be on or after start date")
+                                .font(.caption)
+                                .foregroundColor(.red)
+                        }
                     }
                     .padding(.horizontal)
-                }
-
-                // Specific Date Range Option
-                if selectedDateRangeOption == .specificDateRange {
-                    VStack(alignment: .leading, spacing: 12) {
-                        VStack(alignment: .leading) {
-                            Text("Start Date")
-                                .font(.subheadline)
-                                .foregroundColor(.gray)
-                            DatePicker("", selection: $startDate, displayedComponents: .date)
-                                .datePickerStyle(.compact)
-                        }
-
-                        VStack(alignment: .leading) {
-                            Text("End Date")
-                                .font(.subheadline)
-                                .foregroundColor(.gray)
-                            DatePicker("", selection: $endDate, displayedComponents: .date)
-                                .datePickerStyle(.compact)
-                        }
-                    }
-                    .padding()
-                }
-
-                Spacer()
-
-                if !hasSelectedMetric {
-                    Text("Please select at least one metric")
-                        .font(.caption)
-                        .foregroundColor(.red)
-                }
-
-                if selectedDateRangeOption == .specificDateRange && !isValidDateRange {
-                    Text("End date must be on or after start date")
-                        .font(.caption)
-                        .foregroundColor(.red)
+                    .padding(.top, 8)
+                    .padding(.bottom, 12)
                 }
 
                 Button(action: {
@@ -310,7 +371,6 @@ struct DataSelectionView: View {
                 .padding()
                 .accessibilityIdentifier("exportButton")
             }
-            .padding()
             .disabled(isPreparingExport)
 
             if isPreparingExport {
@@ -323,12 +383,15 @@ struct DataSelectionView: View {
                     .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14))
             }
         }
+        .navigationTitle("Select Data to Export")
+        .navigationBarTitleDisplayMode(.inline)
         .onAppear { updateExportEnabled() }
         .onChange(of: settings.exportWeight) { updateExportEnabled() }
         .onChange(of: settings.exportSteps) { updateExportEnabled() }
         .onChange(of: settings.exportGlucose) { updateExportEnabled() }
         .onChange(of: settings.favoriteLabCodes) { updateExportEnabled() }
         .onChange(of: settings.selectedLabPanels) { updateExportEnabled() }
+        .onChange(of: settings.selectedVitalMetrics) { updateExportEnabled() }
         .onChange(of: selectedDateRangeOption) { updateExportEnabled() }
         .onChange(of: startDate) { updateExportEnabled() }
         .onChange(of: endDate) { updateExportEnabled() }
@@ -387,7 +450,9 @@ struct DataSelectionView: View {
         isPreparingExport = true
 
         let metricsForFetch = labMetricsToFetch
-        healthManager.requestAuthorization(includeLabs: !metricsForFetch.isEmpty) { success, error in
+        let vitalMetricsForFetch = settings.selectedVitalMetrics
+        let vitalComponentsForFetch = vitalComponentsToFetch
+        healthManager.requestAuthorization(includeLabs: !metricsForFetch.isEmpty, vitalMetrics: vitalMetricsForFetch) { success, error in
             guard success else {
                 DispatchQueue.main.async {
                     isPreparingExport = false
@@ -402,10 +467,12 @@ struct DataSelectionView: View {
             var stepsSamples: [HKQuantitySample]? = nil
             var glucoseSamples: [GlucoseSampleMgDl]? = nil
             var labResults: [LabResultSample]? = nil
+            var vitalSamples: [VitalMetricComponent: [HKQuantitySample]] = [:]
             var weightFetchError: Error?
             var stepsFetchError: Error?
             var glucoseFetchError: Error?
             var labFetchError: Error?
+            var vitalFetchError: Error?
             let dispatchGroup = DispatchGroup()
 
             let dateRange = ExportLogic.dateRange(
@@ -463,17 +530,32 @@ struct DataSelectionView: View {
                 }
             }
 
+            for component in vitalComponentsForFetch {
+                dispatchGroup.enter()
+                healthManager.fetchVitalData(component: component, dateRange: dateRange, limit: recordLimit) { samples, error in
+                    DispatchQueue.main.async {
+                        vitalSamples[component] = samples ?? []
+                        if vitalFetchError == nil {
+                            vitalFetchError = error
+                        }
+                        dispatchGroup.leave()
+                    }
+                }
+            }
+
             dispatchGroup.notify(queue: .main) {
                 if let fetchError = ExportLogic.firstFetchError(
                     weightError: weightFetchError,
                     stepsError: stepsFetchError,
                     glucoseError: glucoseFetchError,
-                    labError: labFetchError
+                    labError: labFetchError,
+                    vitalError: vitalFetchError
                 ) {
                     weightSamples = nil
                     stepsSamples = nil
                     glucoseSamples = nil
                     labResults = nil
+                    vitalSamples.removeAll()
                     isPreparingExport = false
                     errorMessage = fetchError.localizedDescription
                     showErrorAlert = true
@@ -484,7 +566,8 @@ struct DataSelectionView: View {
                     weightSamples: weightSamples,
                     stepsSamples: stepsSamples,
                     glucoseSamples: glucoseSamples,
-                    labResults: labResults
+                    labResults: labResults,
+                    vitalSamples: vitalSamples
                 )
 
                 guard hasData else {
@@ -492,6 +575,7 @@ struct DataSelectionView: View {
                     stepsSamples = nil
                     glucoseSamples = nil
                     labResults = nil
+                    vitalSamples.removeAll()
                     isPreparingExport = false
                     errorMessage = ExportError.noDataFound.localizedDescription
                     showErrorAlert = true
@@ -500,18 +584,22 @@ struct DataSelectionView: View {
 
                 let dateFormat = self.settings.dateFormat
                 let weightUnit = self.settings.weightUnit
+                let temperatureUnit = self.settings.temperatureUnit
                 let payload = PendingExportPayload(
                     weightSamples: weightSamples,
                     stepsSamples: stepsSamples,
                     glucoseSamples: glucoseSamples,
-                    labResults: labResults
+                    labResults: labResults,
+                    vitalSamples: vitalSamples
                 )
                 let estimate = CSVGenerator.makePreviewEstimate(
                     weightSamples: payload.weightSamples,
                     stepsSamples: payload.stepsSamples,
                     glucoseSamples: payload.glucoseSamples,
                     labResults: payload.labResults,
+                    vitalSamples: payload.vitalSamples,
                     weightUnit: weightUnit,
+                    temperatureUnit: temperatureUnit,
                     dateFormat: dateFormat
                 )
 
@@ -538,6 +626,7 @@ struct DataSelectionView: View {
         let dateFormat = settings.dateFormat
         let sortOrder = settings.sortOrder
         let weightUnit = settings.weightUnit
+        let temperatureUnit = settings.temperatureUnit
         var csv = CSVGenerator.csvHeader + "\n"
 
         if var samples = payload.weightSamples {
@@ -558,6 +647,10 @@ struct DataSelectionView: View {
         if var samples = payload.labResults {
             payload.labResults = nil
             CSVGenerator.appendLabResultRows(to: &csv, samples: &samples, dateFormat: dateFormat, sortOrder: sortOrder)
+        }
+
+        if !payload.vitalSamples.isEmpty {
+            CSVGenerator.appendVitalRows(to: &csv, samplesByComponent: &payload.vitalSamples, temperatureUnit: temperatureUnit, dateFormat: dateFormat, sortOrder: sortOrder)
         }
 
         csvContent = csv

--- a/HealthExporter/HealthExporter/DataSelectionView.swift
+++ b/HealthExporter/HealthExporter/DataSelectionView.swift
@@ -65,9 +65,8 @@ struct DataSelectionView: View {
     }
 
     private var vitalComponentsToFetch: [VitalMetricComponent] {
-        VitalMetricComponent.allCases.filter { component in
-            settings.selectedVitalMetrics.contains { $0.components.contains(component) }
-        }
+        let components = Set(settings.selectedVitalMetrics.flatMap(\.components))
+        return VitalMetricComponent.allCases.filter { components.contains($0) }
     }
 
     private func updateExportEnabled() {
@@ -131,6 +130,19 @@ struct DataSelectionView: View {
         )
     }
 
+    private func panelExpansionBinding(for panel: LabPanel) -> Binding<Bool> {
+        Binding(
+            get: { settings.expandedLabPanels.contains(panel) },
+            set: { newValue in
+                if newValue {
+                    settings.expandedLabPanels.insert(panel)
+                } else {
+                    settings.expandedLabPanels.remove(panel)
+                }
+            }
+        )
+    }
+
     private func vitalMetricBinding(for metric: VitalMetric) -> Binding<Bool> {
         Binding(
             get: { settings.selectedVitalMetrics.contains(metric) },
@@ -147,17 +159,24 @@ struct DataSelectionView: View {
     private func vitalSectionBinding() -> Binding<Bool> {
         Binding(
             get: {
-                let metrics = Set(VitalMetric.allCases)
-                return !metrics.isEmpty && metrics.isSubset(of: settings.selectedVitalMetrics)
+                VitalMetric.allCasesSet.isSubset(of: settings.selectedVitalMetrics)
             },
             set: { newValue in
                 if newValue {
-                    settings.selectedVitalMetrics.formUnion(VitalMetric.allCases)
+                    settings.selectedVitalMetrics.formUnion(VitalMetric.allCasesSet)
                 } else {
                     settings.selectedVitalMetrics.removeAll()
                 }
             }
         )
+    }
+
+    private func panelSelectedCount(_ panel: LabPanel) -> Int {
+        LabMetricRegistry.metrics(in: panel).reduce(0) { count, metric in
+            let isSelected = settings.favoriteLabCodes.contains(metric.loincCode) ||
+                settings.selectedLabPanels.contains(panel)
+            return count + (isSelected ? 1 : 0)
+        }
     }
 
     private func presentSaveSuccessConfirmation() {
@@ -191,170 +210,218 @@ struct DataSelectionView: View {
         saveSuccessDismissTask = nil
     }
 
-    private func labPanelSection(_ panel: LabPanel) -> some View {
+    private func labPanelDisclosure(_ panel: LabPanel) -> some View {
         let metrics = LabMetricRegistry.metrics(in: panel)
-        return VStack(alignment: .leading, spacing: 6) {
-            Toggle(isOn: labPanelSelectionBinding(for: panel)) {
-                Text(panel.displayName)
-                    .font(.headline)
-            }
-            .accessibilityIdentifier("panel_\(panel.rawValue)")
-
+        let selectedCount = panelSelectedCount(panel)
+        return DisclosureGroup(isExpanded: panelExpansionBinding(for: panel)) {
             ForEach(metrics) { metric in
-                Toggle(isOn: labSelectionBinding(for: metric.loincCode)) {
-                    HStack(spacing: 4) {
-                        Text(metric.name)
-                        Image(systemName: "cross.case")
-                            .font(.caption)
+                Toggle(metric.name, isOn: labSelectionBinding(for: metric.loincCode))
+                    .accessibilityIdentifier("lab_\(metric.loincCode)")
+            }
+        } label: {
+            Toggle(isOn: labPanelSelectionBinding(for: panel)) {
+                HStack(spacing: 6) {
+                    Text(panel.displayName)
+                    if !metrics.isEmpty {
+                        Text("\(selectedCount)/\(metrics.count)")
+                            .font(.footnote)
                             .foregroundColor(.secondary)
+                            .monospacedDigit()
                     }
                 }
-                .padding(.leading, 12)
-                .accessibilityIdentifier("lab_\(metric.loincCode)")
             }
+            .accessibilityIdentifier("panel_\(panel.rawValue)")
         }
     }
 
-    private func vitalsSection() -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Toggle(isOn: vitalSectionBinding()) {
-                Text("Vitals")
-                    .font(.headline)
-            }
-            .accessibilityIdentifier("vitalsSectionToggle")
-
-            ForEach(VitalMetric.allCases) { metric in
+    private func vitalsDisclosure() -> some View {
+        let allVitals = VitalMetric.allCases
+        let selectedCount = settings.selectedVitalMetrics.count
+        return DisclosureGroup(isExpanded: $settings.expandedVitalsSection) {
+            ForEach(allVitals) { metric in
                 Toggle(metric.displayName, isOn: vitalMetricBinding(for: metric))
-                    .padding(.leading, 12)
                     .accessibilityIdentifier("vital_\(metric.rawValue)")
             }
+        } label: {
+            Toggle(isOn: vitalSectionBinding()) {
+                HStack(spacing: 6) {
+                    Text("Vitals")
+                    if !allVitals.isEmpty {
+                        Text("\(selectedCount)/\(allVitals.count)")
+                            .font(.footnote)
+                            .foregroundColor(.secondary)
+                            .monospacedDigit()
+                    }
+                }
+            }
+            .accessibilityIdentifier("vitalsSectionToggle")
         }
+    }
+
+    private static let dateRangeEditorHeight: CGFloat = 90
+
+    private func segmentLabel(for option: DateRangeOption) -> String {
+        switch option {
+        case .lastXDays:         return "Last X\nDays"
+        case .lastXRecords:      return "Last X\nRecords"
+        case .specificDateRange: return "Specific\nDates"
+        case .allRecords:        return "All\nRecords"
+        }
+    }
+
+    private func dateRangeSegmentedPicker() -> some View {
+        HStack(spacing: 2) {
+            ForEach(DateRangeOption.allCases, id: \.self) { option in
+                let isSelected = selectedDateRangeOption == option
+                Button {
+                    selectedDateRangeOption = option
+                } label: {
+                    Text(segmentLabel(for: option))
+                        .font(.footnote)
+                        .multilineTextAlignment(.center)
+                        .lineLimit(2)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(maxWidth: .infinity, minHeight: 36)
+                        .padding(.vertical, 4)
+                        .background(
+                            RoundedRectangle(cornerRadius: 7)
+                                .fill(isSelected ? Color(uiColor: .systemBackground) : Color.clear)
+                                .shadow(color: isSelected ? Color.black.opacity(0.12) : .clear, radius: 1, y: 1)
+                        )
+                        .foregroundColor(.primary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(option.displayName)
+            }
+        }
+        .padding(2)
+        .background(Color(uiColor: .tertiarySystemFill))
+        .cornerRadius(9)
+        .accessibilityIdentifier("dateRangePicker")
+    }
+
+    @ViewBuilder
+    private func dateRangeValueEditor() -> some View {
+        switch selectedDateRangeOption {
+        case .lastXDays:
+            VStack(spacing: 6) {
+                HStack {
+                    Text("Days:")
+                        .font(.subheadline)
+                    Spacer()
+                    Picker("Days", selection: $settings.lastXDaysValue) {
+                        ForEach(DataSelectionView.dayOptions, id: \.self) { days in
+                            Text("\(days)").tag(days)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    .accessibilityLabel("Number of days")
+                }
+                Text(DayRangeSummaryFormatter.summaryText(forDays: settings.lastXDaysValue, relativeTo: Date()))
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+        case .lastXRecords:
+            HStack {
+                Text("Records:")
+                    .font(.subheadline)
+                Spacer()
+                Picker("Records", selection: $settings.lastXRecordsValue) {
+                    ForEach(DataSelectionView.recordOptions, id: \.self) { records in
+                        Text("\(records)").tag(records)
+                    }
+                }
+                .pickerStyle(.menu)
+                .accessibilityLabel("Number of records")
+            }
+
+        case .specificDateRange:
+            VStack(spacing: 6) {
+                HStack {
+                    Text("Start:")
+                        .font(.subheadline)
+                    Spacer()
+                    DatePicker("", selection: $startDate, displayedComponents: .date)
+                        .labelsHidden()
+                }
+                HStack {
+                    Text("End:")
+                        .font(.subheadline)
+                    Spacer()
+                    DatePicker("", selection: $endDate, displayedComponents: .date)
+                        .labelsHidden()
+                }
+            }
+
+        case .allRecords:
+            Text("Exports every available record in the selected metrics.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private func dateRangeFooter() -> some View {
+        VStack(spacing: 10) {
+            dateRangeSegmentedPicker()
+
+            dateRangeValueEditor()
+                .frame(height: Self.dateRangeEditorHeight, alignment: .top)
+
+            if !hasSelectedMetric {
+                Text("Please select at least one metric")
+                    .font(.caption)
+                    .foregroundColor(.red)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            if selectedDateRangeOption == .specificDateRange && !isValidDateRange {
+                Text("End date must be on or after start date")
+                    .font(.caption)
+                    .foregroundColor(.red)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 12)
+        .background(Color(uiColor: .secondarySystemBackground))
     }
 
     var body: some View {
         ZStack {
             VStack(spacing: 0) {
-                ScrollView {
-                    VStack(alignment: .leading, spacing: 12) {
-                        Toggle(isOn: $settings.exportWeight) {
-                            Text("Weight")
-                        }
-                        .accessibilityIdentifier("weightToggle")
-
-                        Toggle(isOn: $settings.exportSteps) {
-                            Text("Steps")
-                        }
-                        .accessibilityIdentifier("stepsToggle")
-
-                        Toggle(isOn: $settings.exportGlucose) {
-                            Text("Blood Glucose (mg/dL)")
-                        }
-                        .accessibilityIdentifier("glucoseToggle")
-
-                        ForEach(LabPanel.allCases, id: \.self) { panel in
-                            labPanelSection(panel)
-                        }
-
-                        HStack(spacing: 4) {
-                            Image(systemName: "cross.case")
-                                .font(.caption2)
-                                .foregroundColor(.secondary)
-                            Text("Lab sections require access to Clinical Health Records")
-                                .font(.caption2)
-                                .foregroundColor(.secondary)
-                        }
-                        .frame(maxWidth: .infinity, alignment: .leading)
-
-                        vitalsSection()
-
-                        Divider()
-                            .padding(.vertical, 8)
-
-                        Text("Date Range")
-                            .font(.headline)
-                            .frame(maxWidth: .infinity, alignment: .center)
-
-                        Picker("Date Range", selection: $selectedDateRangeOption) {
-                            ForEach(DateRangeOption.allCases, id: \.self) { option in
-                                Text(option.displayName).tag(option)
-                            }
-                        }
-                        .pickerStyle(.segmented)
-                        .accessibilityIdentifier("dateRangePicker")
-
-                        if selectedDateRangeOption == .lastXDays {
-                            VStack(spacing: 4) {
-                                Text("Days:")
-                                    .font(.subheadline)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                Picker("Days", selection: $settings.lastXDaysValue) {
-                                    ForEach(DataSelectionView.dayOptions, id: \.self) { days in
-                                        Text("\(days)").tag(days)
-                                    }
-                                }
-                                .pickerStyle(.wheel)
-                                .frame(height: 120)
-                                .accessibilityLabel("Number of days")
-
-                                Text(DayRangeSummaryFormatter.summaryText(forDays: settings.lastXDaysValue, relativeTo: Date()))
-                                    .font(.caption)
-                                    .foregroundColor(.secondary)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                            }
-                        }
-
-                        if selectedDateRangeOption == .lastXRecords {
-                            VStack(spacing: 4) {
-                                Text("Records:")
-                                    .font(.subheadline)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                Picker("Records", selection: $settings.lastXRecordsValue) {
-                                    ForEach(DataSelectionView.recordOptions, id: \.self) { records in
-                                        Text("\(records)").tag(records)
-                                    }
-                                }
-                                .pickerStyle(.wheel)
-                                .frame(height: 120)
-                                .accessibilityLabel("Number of records")
-                            }
-                        }
-
-                        if selectedDateRangeOption == .specificDateRange {
-                            VStack(alignment: .leading, spacing: 12) {
-                                VStack(alignment: .leading) {
-                                    Text("Start Date")
-                                        .font(.subheadline)
-                                        .foregroundColor(.gray)
-                                    DatePicker("", selection: $startDate, displayedComponents: .date)
-                                        .datePickerStyle(.compact)
-                                }
-
-                                VStack(alignment: .leading) {
-                                    Text("End Date")
-                                        .font(.subheadline)
-                                        .foregroundColor(.gray)
-                                    DatePicker("", selection: $endDate, displayedComponents: .date)
-                                        .datePickerStyle(.compact)
-                                }
-                            }
-                        }
-
-                        if !hasSelectedMetric {
-                            Text("Please select at least one metric")
-                                .font(.caption)
-                                .foregroundColor(.red)
-                        }
-
-                        if selectedDateRangeOption == .specificDateRange && !isValidDateRange {
-                            Text("End date must be on or after start date")
-                                .font(.caption)
-                                .foregroundColor(.red)
-                        }
+                Form {
+                    Section {
+                        Toggle("Weight", isOn: $settings.exportWeight)
+                            .accessibilityIdentifier("weightToggle")
+                        Toggle("Steps", isOn: $settings.exportSteps)
+                            .accessibilityIdentifier("stepsToggle")
+                        Toggle("Blood Glucose (mg/dL)", isOn: $settings.exportGlucose)
+                            .accessibilityIdentifier("glucoseToggle")
+                    } header: {
+                        Label("Activity & Glucose", systemImage: "figure.walk")
                     }
-                    .padding(.horizontal)
-                    .padding(.top, 8)
-                    .padding(.bottom, 12)
+
+                    Section {
+                        ForEach(LabPanel.allCases, id: \.self) { panel in
+                            labPanelDisclosure(panel)
+                        }
+                    } header: {
+                        Label("Labs", systemImage: "cross.case")
+                    } footer: {
+                        Text("Lab sections require access to Clinical Health Records.")
+                    }
+
+                    Section {
+                        vitalsDisclosure()
+                    } header: {
+                        Label("Vitals", systemImage: "heart.text.square")
+                    }
                 }
+
+                dateRangeFooter()
 
                 Button(action: {
                     exportData()
@@ -368,7 +435,8 @@ struct DataSelectionView: View {
                         .cornerRadius(10)
                 }
                 .disabled(!exportEnabled || isPreparingExport)
-                .padding()
+                .padding(.horizontal)
+                .padding(.vertical, 10)
                 .accessibilityIdentifier("exportButton")
             }
             .disabled(isPreparingExport)
@@ -535,6 +603,8 @@ struct DataSelectionView: View {
                 healthManager.fetchVitalData(component: component, dateRange: dateRange, limit: recordLimit) { samples, error in
                     DispatchQueue.main.async {
                         vitalSamples[component] = samples ?? []
+                        // Surface the first vital component error; downstream code reports a single error
+                        // for the whole vitals group rather than overwhelming the user with per-component failures.
                         if vitalFetchError == nil {
                             vitalFetchError = error
                         }

--- a/HealthExporter/HealthExporter/ExportLogic.swift
+++ b/HealthExporter/HealthExporter/ExportLogic.swift
@@ -10,11 +10,12 @@ enum ExportLogic {
         exportSteps: Bool,
         exportGlucose: Bool,
         hasSelectedLabs: Bool,
+        hasSelectedVitals: Bool = false,
         dateRangeOption: DateRangeOption,
         startDate: Date,
         endDate: Date
     ) -> Bool {
-        let hasSelectedMetric = exportWeight || exportSteps || exportGlucose || hasSelectedLabs
+        let hasSelectedMetric = exportWeight || exportSteps || exportGlucose || hasSelectedLabs || hasSelectedVitals
         guard hasSelectedMetric else { return false }
 
         switch dateRangeOption {
@@ -70,7 +71,8 @@ enum ExportLogic {
         weightError: Error?,
         stepsError: Error?,
         glucoseError: Error?,
-        labError: Error?
+        labError: Error?,
+        vitalError: Error? = nil
     ) -> ExportError? {
         if let weightError {
             return .healthKitQueryFailed(metric: HealthMetrics.weight.name, underlying: weightError)
@@ -83,6 +85,9 @@ enum ExportLogic {
         }
         if let labError {
             return .healthKitQueryFailed(metric: "Lab Results", underlying: labError)
+        }
+        if let vitalError {
+            return .healthKitQueryFailed(metric: "Vitals", underlying: vitalError)
         }
         return nil
     }
@@ -102,12 +107,14 @@ enum ExportLogic {
         weightSamples: [HKQuantitySample]?,
         stepsSamples: [HKQuantitySample]?,
         glucoseSamples: [GlucoseSampleMgDl]?,
-        labResults: [LabResultSample]?
+        labResults: [LabResultSample]?,
+        vitalSamples: [VitalMetricComponent: [HKQuantitySample]]? = nil
     ) -> Bool {
         (weightSamples?.isEmpty == false) ||
         (stepsSamples?.isEmpty == false) ||
         (glucoseSamples?.isEmpty == false) ||
-        (labResults?.isEmpty == false)
+        (labResults?.isEmpty == false) ||
+        (vitalSamples?.values.contains { !$0.isEmpty } == true)
     }
 
     /// Generates the export filename for a given date.

--- a/HealthExporter/HealthExporter/HealthKitManager.swift
+++ b/HealthExporter/HealthExporter/HealthKitManager.swift
@@ -5,12 +5,18 @@ import os
 enum HealthKitQueryHelpers {
 
     /// The set of HealthKit types to request read access for.
-    static func readTypes(includeLabs: Bool) -> Set<HKObjectType> {
+    static func readTypes(includeLabs: Bool, vitalMetrics: Set<VitalMetric> = []) -> Set<HKObjectType> {
         let weightType = HKQuantityType.quantityType(forIdentifier: .bodyMass)!
         let stepsType = HKQuantityType.quantityType(forIdentifier: .stepCount)!
         let glucoseType = HKQuantityType.quantityType(forIdentifier: .bloodGlucose)!
 
         var types: Set<HKObjectType> = [weightType, stepsType, glucoseType]
+
+        for component in vitalMetrics.flatMap(\.components) {
+            if let type = HKQuantityType.quantityType(forIdentifier: component.healthKitIdentifier) {
+                types.insert(type)
+            }
+        }
 
         if includeLabs,
            let clinicalType = HKObjectType.clinicalType(forIdentifier: .labResultRecord) {
@@ -105,13 +111,13 @@ class HealthKitManager {
     let healthStore = HKHealthStore()
     private static let logger = Logger(subsystem: "com.HealthExporter", category: "HealthKit")
     
-    func requestAuthorization(includeLabs: Bool = false, completion: @escaping (Bool, Error?) -> Void) {
+    func requestAuthorization(includeLabs: Bool = false, vitalMetrics: Set<VitalMetric> = [], completion: @escaping (Bool, Error?) -> Void) {
         guard HKHealthStore.isHealthDataAvailable() else {
             completion(false, NSError(domain: "HealthKit", code: 1, userInfo: [NSLocalizedDescriptionKey: "HealthKit is not available"]))
             return
         }
 
-        let typesToRead = HealthKitQueryHelpers.readTypes(includeLabs: includeLabs)
+        let typesToRead = HealthKitQueryHelpers.readTypes(includeLabs: includeLabs, vitalMetrics: vitalMetrics)
 
         healthStore.requestAuthorization(toShare: Set(), read: typesToRead) { success, error in
             completion(success, error)
@@ -175,6 +181,28 @@ class HealthKitManager {
             let glucoseSamples = rawSamples?.compactMap { GlucoseSampleMgDl(from: $0) }
             Self.logger.debug("Glucose samples after filtering: \(glucoseSamples?.count ?? 0)")
             completion(glucoseSamples, error)
+        }
+        healthStore.execute(query)
+    }
+
+    func fetchVitalData(component: VitalMetricComponent, dateRange: (startDate: Date, endDate: Date)? = nil, limit: Int = HKObjectQueryNoLimit, completion: @escaping ([HKQuantitySample]?, Error?) -> Void) {
+        guard let quantityType = HKQuantityType.quantityType(forIdentifier: component.healthKitIdentifier) else {
+            completion(nil, NSError(domain: "HealthKit", code: 4, userInfo: [NSLocalizedDescriptionKey: "\(component.displayName) type not available"]))
+            return
+        }
+
+        var predicate: NSPredicate? = nil
+        if let dateRange = dateRange {
+            predicate = HealthKitQueryHelpers.predicateForDateRange(dateRange)
+            if predicate == nil {
+                completion(nil, nil)
+                return
+            }
+        }
+
+        let sortDescriptor = NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: false)
+        let query = HKSampleQuery(sampleType: quantityType, predicate: predicate, limit: limit, sortDescriptors: [sortDescriptor]) { _, samples, error in
+            completion(samples as? [HKQuantitySample], error)
         }
         healthStore.execute(query)
     }

--- a/HealthExporter/HealthExporter/HealthSampleTypes.swift
+++ b/HealthExporter/HealthExporter/HealthSampleTypes.swift
@@ -27,10 +27,48 @@ struct GlucoseSampleMgDl {
 /// Common LOINC codes for lab results
 struct LOINCCode {
     static let hemoglobinA1C = "4548-4"
+
     static let totalCholesterol = "2093-3"
     static let hdlCholesterol = "2085-9"
     static let ldlCholesterolDirect = "2089-1"
     static let triglycerides = "2571-8"
+
+    static let whiteBloodCellCount = "6690-2"
+    static let redBloodCellCount = "789-8"
+    static let hemoglobin = "718-7"
+    static let hematocrit = "4544-3"
+    static let platelets = "777-3"
+    static let meanCorpuscularVolume = "787-2"
+    static let meanCorpuscularHemoglobin = "785-6"
+    static let meanCorpuscularHemoglobinConcentration = "786-4"
+    static let redCellDistributionWidth = "788-0"
+
+    static let fastingGlucose = "1558-6"
+    static let bloodUreaNitrogen = "3094-0"
+    static let creatinine = "2160-0"
+    static let estimatedGlomerularFiltrationRate = "33914-3"
+    static let sodium = "2951-2"
+    static let potassium = "2823-3"
+    static let chloride = "2075-0"
+    static let carbonDioxideBicarbonate = "2028-9"
+    static let calcium = "17861-6"
+    static let totalProtein = "2885-2"
+    static let albumin = "1751-7"
+    static let bilirubinTotal = "1975-2"
+    static let alanineAminotransferase = "1742-6"
+    static let aspartateAminotransferase = "1920-8"
+    static let alkalinePhosphatase = "6768-6"
+
+    static let thyroidStimulatingHormone = "3016-3"
+    static let freeT4 = "3024-7"
+    static let freeT3 = "3051-0"
+
+    static let vitaminD25Hydroxy = "1989-3"
+    static let vitaminB12 = "2132-9"
+    static let ferritin = "2276-4"
+    static let iron = "2498-4"
+    static let totalIronBindingCapacity = "2500-7"
+    static let highSensitivityCRP = "30522-7"
 }
 
 // MARK: - FHIR Lab Result Helper

--- a/HealthExporter/HealthExporter/HealthSampleTypes.swift
+++ b/HealthExporter/HealthExporter/HealthSampleTypes.swift
@@ -27,11 +27,10 @@ struct GlucoseSampleMgDl {
 /// Common LOINC codes for lab results
 struct LOINCCode {
     static let hemoglobinA1C = "4548-4"
-    // Add future LOINC codes here:
-    // static let totalCholesterol = "2093-3"
-    // static let hdlCholesterol = "2085-9"
-    // static let ldlCholesterol = "2089-1"
-    // static let triglycerides = "2571-8"
+    static let totalCholesterol = "2093-3"
+    static let hdlCholesterol = "2085-9"
+    static let ldlCholesterolDirect = "2089-1"
+    static let triglycerides = "2571-8"
 }
 
 // MARK: - FHIR Lab Result Helper
@@ -144,4 +143,3 @@ struct LabResultSample {
         )
     }
 }
-

--- a/HealthExporter/HealthExporter/LabMetricRegistry.swift
+++ b/HealthExporter/HealthExporter/LabMetricRegistry.swift
@@ -10,9 +10,9 @@ enum LabPanel: String, CaseIterable, Codable {
 
     var displayName: String {
         switch self {
-        case .lipid: return "Lipid Panel"
+        case .lipid: return "Lipid panel"
         case .cbc: return "CBC"
-        case .cmp: return "CMP"
+        case .cmp: return "CMP / BMP"
         case .thyroid: return "Thyroid"
         case .other: return "Other"
         }
@@ -63,6 +63,204 @@ enum LabMetricRegistry {
             loincCode: LOINCCode.triglycerides,
             group: .lipid,
             valuePrecision: 0
+        ),
+        LabMetric(
+            name: "WBC",
+            loincCode: LOINCCode.whiteBloodCellCount,
+            group: .cbc,
+            valuePrecision: 2
+        ),
+        LabMetric(
+            name: "RBC",
+            loincCode: LOINCCode.redBloodCellCount,
+            group: .cbc,
+            valuePrecision: 2
+        ),
+        LabMetric(
+            name: "Hemoglobin",
+            loincCode: LOINCCode.hemoglobin,
+            group: .cbc,
+            valuePrecision: 1
+        ),
+        LabMetric(
+            name: "Hematocrit",
+            loincCode: LOINCCode.hematocrit,
+            group: .cbc,
+            valuePrecision: 1
+        ),
+        LabMetric(
+            name: "Platelets",
+            loincCode: LOINCCode.platelets,
+            group: .cbc,
+            valuePrecision: 0
+        ),
+        LabMetric(
+            name: "MCV",
+            loincCode: LOINCCode.meanCorpuscularVolume,
+            group: .cbc,
+            valuePrecision: 1
+        ),
+        LabMetric(
+            name: "MCH",
+            loincCode: LOINCCode.meanCorpuscularHemoglobin,
+            group: .cbc,
+            valuePrecision: 1
+        ),
+        LabMetric(
+            name: "MCHC",
+            loincCode: LOINCCode.meanCorpuscularHemoglobinConcentration,
+            group: .cbc,
+            valuePrecision: 1
+        ),
+        LabMetric(
+            name: "RDW",
+            loincCode: LOINCCode.redCellDistributionWidth,
+            group: .cbc,
+            valuePrecision: 1
+        ),
+        LabMetric(
+            name: "Fasting Glucose",
+            loincCode: LOINCCode.fastingGlucose,
+            group: .cmp,
+            valuePrecision: 0
+        ),
+        LabMetric(
+            name: "BUN",
+            loincCode: LOINCCode.bloodUreaNitrogen,
+            group: .cmp,
+            valuePrecision: 0
+        ),
+        LabMetric(
+            name: "Creatinine",
+            loincCode: LOINCCode.creatinine,
+            group: .cmp,
+            valuePrecision: 2
+        ),
+        LabMetric(
+            name: "eGFR",
+            loincCode: LOINCCode.estimatedGlomerularFiltrationRate,
+            group: .cmp,
+            valuePrecision: 0
+        ),
+        LabMetric(
+            name: "Sodium",
+            loincCode: LOINCCode.sodium,
+            group: .cmp,
+            valuePrecision: 0
+        ),
+        LabMetric(
+            name: "Potassium",
+            loincCode: LOINCCode.potassium,
+            group: .cmp,
+            valuePrecision: 1
+        ),
+        LabMetric(
+            name: "Chloride",
+            loincCode: LOINCCode.chloride,
+            group: .cmp,
+            valuePrecision: 0
+        ),
+        LabMetric(
+            name: "CO2 / Bicarbonate",
+            loincCode: LOINCCode.carbonDioxideBicarbonate,
+            group: .cmp,
+            valuePrecision: 0
+        ),
+        LabMetric(
+            name: "Calcium",
+            loincCode: LOINCCode.calcium,
+            group: .cmp,
+            valuePrecision: 1
+        ),
+        LabMetric(
+            name: "Total Protein",
+            loincCode: LOINCCode.totalProtein,
+            group: .cmp,
+            valuePrecision: 1
+        ),
+        LabMetric(
+            name: "Albumin",
+            loincCode: LOINCCode.albumin,
+            group: .cmp,
+            valuePrecision: 1
+        ),
+        LabMetric(
+            name: "Bilirubin Total",
+            loincCode: LOINCCode.bilirubinTotal,
+            group: .cmp,
+            valuePrecision: 1
+        ),
+        LabMetric(
+            name: "ALT",
+            loincCode: LOINCCode.alanineAminotransferase,
+            group: .cmp,
+            valuePrecision: 0
+        ),
+        LabMetric(
+            name: "AST",
+            loincCode: LOINCCode.aspartateAminotransferase,
+            group: .cmp,
+            valuePrecision: 0
+        ),
+        LabMetric(
+            name: "Alkaline Phosphatase",
+            loincCode: LOINCCode.alkalinePhosphatase,
+            group: .cmp,
+            valuePrecision: 0
+        ),
+        LabMetric(
+            name: "TSH",
+            loincCode: LOINCCode.thyroidStimulatingHormone,
+            group: .thyroid,
+            valuePrecision: 2
+        ),
+        LabMetric(
+            name: "Free T4",
+            loincCode: LOINCCode.freeT4,
+            group: .thyroid,
+            valuePrecision: 2
+        ),
+        LabMetric(
+            name: "Free T3",
+            loincCode: LOINCCode.freeT3,
+            group: .thyroid,
+            valuePrecision: 2
+        ),
+        LabMetric(
+            name: "25-OH Vitamin D",
+            loincCode: LOINCCode.vitaminD25Hydroxy,
+            group: .other,
+            valuePrecision: 0
+        ),
+        LabMetric(
+            name: "Vitamin B12",
+            loincCode: LOINCCode.vitaminB12,
+            group: .other,
+            valuePrecision: 0
+        ),
+        LabMetric(
+            name: "Ferritin",
+            loincCode: LOINCCode.ferritin,
+            group: .other,
+            valuePrecision: 0
+        ),
+        LabMetric(
+            name: "Iron",
+            loincCode: LOINCCode.iron,
+            group: .other,
+            valuePrecision: 0
+        ),
+        LabMetric(
+            name: "TIBC",
+            loincCode: LOINCCode.totalIronBindingCapacity,
+            group: .other,
+            valuePrecision: 0
+        ),
+        LabMetric(
+            name: "hs-CRP",
+            loincCode: LOINCCode.highSensitivityCRP,
+            group: .other,
+            valuePrecision: 2
         )
     ]
 

--- a/HealthExporter/HealthExporter/LabMetricRegistry.swift
+++ b/HealthExporter/HealthExporter/LabMetricRegistry.swift
@@ -39,6 +39,30 @@ enum LabMetricRegistry {
             loincCode: LOINCCode.hemoglobinA1C,
             group: .other,
             valuePrecision: 2
+        ),
+        LabMetric(
+            name: "Total Cholesterol",
+            loincCode: LOINCCode.totalCholesterol,
+            group: .lipid,
+            valuePrecision: 0
+        ),
+        LabMetric(
+            name: "HDL Cholesterol",
+            loincCode: LOINCCode.hdlCholesterol,
+            group: .lipid,
+            valuePrecision: 0
+        ),
+        LabMetric(
+            name: "LDL Cholesterol",
+            loincCode: LOINCCode.ldlCholesterolDirect,
+            group: .lipid,
+            valuePrecision: 0
+        ),
+        LabMetric(
+            name: "Triglycerides",
+            loincCode: LOINCCode.triglycerides,
+            group: .lipid,
+            valuePrecision: 0
         )
     ]
 

--- a/HealthExporter/HealthExporter/PrivacyPolicyView.swift
+++ b/HealthExporter/HealthExporter/PrivacyPolicyView.swift
@@ -23,7 +23,7 @@ struct PrivacyPolicyView: View {
                         • Weight
                         • Step Count
                         • Blood Glucose
-                        • Hemoglobin A1C
+                        • Selected clinical lab results, such as Hemoglobin A1C and lipid panel labs
 
                         You control exactly which data types to share through the Apple Health permissions dialog.
                         """)

--- a/HealthExporter/HealthExporter/PrivacyPolicyView.swift
+++ b/HealthExporter/HealthExporter/PrivacyPolicyView.swift
@@ -9,7 +9,7 @@ struct PrivacyPolicyView: View {
                         .font(.title)
                         .fontWeight(.bold)
 
-                    Text("Last updated: March 2026")
+                    Text("Last updated: May 2026")
                         .font(.caption)
                         .foregroundColor(.secondary)
 
@@ -23,7 +23,8 @@ struct PrivacyPolicyView: View {
                         • Weight
                         • Step Count
                         • Blood Glucose
-                        • Selected clinical lab results, such as Hemoglobin A1C and lipid panel labs
+                        • Selected clinical lab results, such as Hemoglobin A1C, lipid panel, CBC, CMP / BMP, thyroid, and other tracked labs
+                        • Selected vitals, such as blood pressure, resting heart rate, heart rate variability, oxygen saturation, respiratory rate, and body temperature
 
                         You control exactly which data types to share through the Apple Health permissions dialog.
                         """)

--- a/HealthExporter/HealthExporter/SettingsManager.swift
+++ b/HealthExporter/HealthExporter/SettingsManager.swift
@@ -64,6 +64,8 @@ class SettingsManager: ObservableObject {
     @Published var selectedLabPanels: Set<LabPanel>
     @Published var favoriteLabCodes: Set<String>
     @Published var selectedVitalMetrics: Set<VitalMetric>
+    @Published var expandedLabPanels: Set<LabPanel>
+    @Published var expandedVitalsSection: Bool
     @Published var dateFormat: DateFormatOption
     @Published var sortOrder: SortOrder
     @Published var lastXDaysValue: Int
@@ -114,6 +116,11 @@ class SettingsManager: ObservableObject {
 
         let vitalsRaw = UserDefaults.standard.array(forKey: "selectedVitalMetrics") as? [String] ?? []
         self.selectedVitalMetrics = Set(vitalsRaw.compactMap(VitalMetric.init(rawValue:)))
+
+        let expandedPanelsRaw = UserDefaults.standard.array(forKey: "expandedLabPanels") as? [String] ?? []
+        self.expandedLabPanels = Set(expandedPanelsRaw.compactMap(LabPanel.init(rawValue:)))
+
+        self.expandedVitalsSection = UserDefaults.standard.object(forKey: "expandedVitalsSection") as? Bool ?? false
 
         self.lastXDaysValue = UserDefaults.standard.object(forKey: "lastXDaysValue") as? Int ?? 30
         self.lastXRecordsValue = UserDefaults.standard.object(forKey: "lastXRecordsValue") as? Int ?? 100
@@ -177,6 +184,16 @@ class SettingsManager: ObservableObject {
         $selectedVitalMetrics
             .dropFirst()
             .sink { UserDefaults.standard.set($0.map(\.rawValue), forKey: "selectedVitalMetrics") }
+            .store(in: &cancellables)
+
+        $expandedLabPanels
+            .dropFirst()
+            .sink { UserDefaults.standard.set($0.map(\.rawValue), forKey: "expandedLabPanels") }
+            .store(in: &cancellables)
+
+        $expandedVitalsSection
+            .dropFirst()
+            .sink { UserDefaults.standard.set($0, forKey: "expandedVitalsSection") }
             .store(in: &cancellables)
 
         $lastXDaysValue

--- a/HealthExporter/HealthExporter/SettingsManager.swift
+++ b/HealthExporter/HealthExporter/SettingsManager.swift
@@ -63,6 +63,7 @@ class SettingsManager: ObservableObject {
     @Published var exportGlucose: Bool
     @Published var selectedLabPanels: Set<LabPanel>
     @Published var favoriteLabCodes: Set<String>
+    @Published var selectedVitalMetrics: Set<VitalMetric>
     @Published var dateFormat: DateFormatOption
     @Published var sortOrder: SortOrder
     @Published var lastXDaysValue: Int
@@ -110,6 +111,9 @@ class SettingsManager: ObservableObject {
 
         let favoritesRaw = UserDefaults.standard.array(forKey: "favoriteLabCodes") as? [String] ?? []
         self.favoriteLabCodes = Set(favoritesRaw)
+
+        let vitalsRaw = UserDefaults.standard.array(forKey: "selectedVitalMetrics") as? [String] ?? []
+        self.selectedVitalMetrics = Set(vitalsRaw.compactMap(VitalMetric.init(rawValue:)))
 
         self.lastXDaysValue = UserDefaults.standard.object(forKey: "lastXDaysValue") as? Int ?? 30
         self.lastXRecordsValue = UserDefaults.standard.object(forKey: "lastXRecordsValue") as? Int ?? 100
@@ -168,6 +172,11 @@ class SettingsManager: ObservableObject {
         $favoriteLabCodes
             .dropFirst()
             .sink { UserDefaults.standard.set(Array($0), forKey: "favoriteLabCodes") }
+            .store(in: &cancellables)
+
+        $selectedVitalMetrics
+            .dropFirst()
+            .sink { UserDefaults.standard.set($0.map(\.rawValue), forKey: "selectedVitalMetrics") }
             .store(in: &cancellables)
 
         $lastXDaysValue

--- a/HealthExporter/HealthExporter/VitalMetricRegistry.swift
+++ b/HealthExporter/HealthExporter/VitalMetricRegistry.swift
@@ -10,6 +10,8 @@ enum VitalMetric: String, CaseIterable, Codable, Identifiable, Hashable {
     case respiratoryRate
     case bodyTemperature
 
+    static let allCasesSet: Set<VitalMetric> = Set(allCases)
+
     var id: String { rawValue }
 
     var displayName: String {

--- a/HealthExporter/HealthExporter/VitalMetricRegistry.swift
+++ b/HealthExporter/HealthExporter/VitalMetricRegistry.swift
@@ -1,0 +1,110 @@
+import HealthKit
+
+/// Higher-level vitals users can select in the export UI.
+/// Some selections expand to multiple CSV rows, such as Blood Pressure.
+enum VitalMetric: String, CaseIterable, Codable, Identifiable, Hashable {
+    case bloodPressure
+    case restingHeartRate
+    case heartRateVariabilitySDNN
+    case oxygenSaturation
+    case respiratoryRate
+    case bodyTemperature
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .bloodPressure: return "Blood Pressure"
+        case .restingHeartRate: return "Resting Heart Rate"
+        case .heartRateVariabilitySDNN: return "Heart Rate Variability (SDNN)"
+        case .oxygenSaturation: return "Oxygen Saturation (SpO₂)"
+        case .respiratoryRate: return "Respiratory Rate"
+        case .bodyTemperature: return "Body Temperature"
+        }
+    }
+
+    var components: [VitalMetricComponent] {
+        switch self {
+        case .bloodPressure:
+            return [.bloodPressureSystolic, .bloodPressureDiastolic]
+        case .restingHeartRate:
+            return [.restingHeartRate]
+        case .heartRateVariabilitySDNN:
+            return [.heartRateVariabilitySDNN]
+        case .oxygenSaturation:
+            return [.oxygenSaturation]
+        case .respiratoryRate:
+            return [.respiratoryRate]
+        case .bodyTemperature:
+            return [.bodyTemperature]
+        }
+    }
+}
+
+/// Concrete HealthKit quantity rows emitted for selected vitals.
+enum VitalMetricComponent: String, CaseIterable, Identifiable, Hashable {
+    case bloodPressureSystolic
+    case bloodPressureDiastolic
+    case restingHeartRate
+    case heartRateVariabilitySDNN
+    case oxygenSaturation
+    case respiratoryRate
+    case bodyTemperature
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .bloodPressureSystolic: return "Blood Pressure Systolic"
+        case .bloodPressureDiastolic: return "Blood Pressure Diastolic"
+        case .restingHeartRate: return "Resting Heart Rate"
+        case .heartRateVariabilitySDNN: return "Heart Rate Variability (SDNN)"
+        case .oxygenSaturation: return "Oxygen Saturation"
+        case .respiratoryRate: return "Respiratory Rate"
+        case .bodyTemperature: return "Body Temperature"
+        }
+    }
+
+    var healthKitIdentifier: HKQuantityTypeIdentifier {
+        switch self {
+        case .bloodPressureSystolic: return .bloodPressureSystolic
+        case .bloodPressureDiastolic: return .bloodPressureDiastolic
+        case .restingHeartRate: return .restingHeartRate
+        case .heartRateVariabilitySDNN: return .heartRateVariabilitySDNN
+        case .oxygenSaturation: return .oxygenSaturation
+        case .respiratoryRate: return .respiratoryRate
+        case .bodyTemperature: return .bodyTemperature
+        }
+    }
+
+    var valuePrecision: Int {
+        switch self {
+        case .bodyTemperature, .oxygenSaturation, .respiratoryRate:
+            return 1
+        case .bloodPressureSystolic, .bloodPressureDiastolic, .restingHeartRate, .heartRateVariabilitySDNN:
+            return 0
+        }
+    }
+
+    func valueAndUnit(from quantity: HKQuantity, temperatureUnit: TemperatureUnit) -> (value: Double, unit: String) {
+        switch self {
+        case .bloodPressureSystolic, .bloodPressureDiastolic:
+            return (quantity.doubleValue(for: HKUnit.millimeterOfMercury()), "mmHg")
+        case .restingHeartRate:
+            return (quantity.doubleValue(for: HKUnit.count().unitDivided(by: HKUnit.minute())), "bpm")
+        case .heartRateVariabilitySDNN:
+            return (quantity.doubleValue(for: HKUnit.secondUnit(with: .milli)), "ms")
+        case .oxygenSaturation:
+            return (quantity.doubleValue(for: HKUnit.percent()) * 100, "%")
+        case .respiratoryRate:
+            return (quantity.doubleValue(for: HKUnit.count().unitDivided(by: HKUnit.minute())), "breaths/min")
+        case .bodyTemperature:
+            switch temperatureUnit {
+            case .celsius:
+                return (quantity.doubleValue(for: HKUnit.degreeCelsius()), "°C")
+            case .fahrenheit:
+                return (quantity.doubleValue(for: HKUnit.degreeFahrenheit()), "°F")
+            }
+        }
+    }
+}

--- a/HealthExporterTests/CSVGeneratorTests.swift
+++ b/HealthExporterTests/CSVGeneratorTests.swift
@@ -341,6 +341,25 @@ final class CSVGeneratorTests: XCTestCase {
         XCTAssertTrue(csv.contains(",7.00,%,"))
     }
 
+    func testLabResultRow_usesZeroPrecision_forLipidMetrics() {
+        let sample = LabResultSample(
+            metricName: "Total Cholesterol",
+            loincCode: LOINCCode.totalCholesterol,
+            effectiveDateTime: referenceDate,
+            value: 201.6,
+            unit: "mg/dL",
+            source: "Lab"
+        )
+        let csv = CSVGenerator.generateCombinedCSV(
+            weightSamples: nil,
+            stepsSamples: nil,
+            glucoseSamples: nil,
+            labResults: [sample],
+            weightUnit: .kilograms
+        )
+        XCTAssertTrue(csv.contains(",Total Cholesterol,202,mg/dL,"))
+    }
+
     func testLabResultRow_unknownLoinc_defaultsToTwoDecimals() {
         // Registry has no entry for this code, so precision falls back to 2.
         let sample = LabResultSample(

--- a/HealthExporterTests/CSVGeneratorTests.swift
+++ b/HealthExporterTests/CSVGeneratorTests.swift
@@ -7,6 +7,10 @@ final class CSVGeneratorTests: XCTestCase {
     private let weightType = HKQuantityType.quantityType(forIdentifier: .bodyMass)!
     private let stepsType = HKQuantityType.quantityType(forIdentifier: .stepCount)!
     private let glucoseType = HKQuantityType.quantityType(forIdentifier: .bloodGlucose)!
+    private let systolicType = HKQuantityType.quantityType(forIdentifier: .bloodPressureSystolic)!
+    private let diastolicType = HKQuantityType.quantityType(forIdentifier: .bloodPressureDiastolic)!
+    private let oxygenType = HKQuantityType.quantityType(forIdentifier: .oxygenSaturation)!
+    private let bodyTemperatureType = HKQuantityType.quantityType(forIdentifier: .bodyTemperature)!
     private let mgDlUnit = HKUnit.gramUnit(with: .milli).unitDivided(by: HKUnit.literUnit(with: .deci))
 
     /// A fixed reference date (2024-01-15 09:30:00 UTC) for deterministic test output.
@@ -250,6 +254,79 @@ final class CSVGeneratorTests: XCTestCase {
         XCTAssertTrue(csv.contains(",Weight,"))
         XCTAssertTrue(csv.contains(",Steps,"))
         XCTAssertTrue(csv.contains(",Blood Glucose,"))
+    }
+
+    func testGenerateCombinedCSV_bloodPressure_containsPairedRows() {
+        let systolic = HKQuantitySample(
+            type: systolicType,
+            quantity: HKQuantity(unit: .millimeterOfMercury(), doubleValue: 120),
+            start: referenceDate,
+            end: referenceDate
+        )
+        let diastolic = HKQuantitySample(
+            type: diastolicType,
+            quantity: HKQuantity(unit: .millimeterOfMercury(), doubleValue: 80),
+            start: referenceDate,
+            end: referenceDate
+        )
+
+        let csv = CSVGenerator.generateCombinedCSV(
+            weightSamples: nil,
+            stepsSamples: nil,
+            glucoseSamples: nil,
+            labResults: nil,
+            vitalSamples: [
+                .bloodPressureSystolic: [systolic],
+                .bloodPressureDiastolic: [diastolic]
+            ],
+            weightUnit: .kilograms
+        )
+
+        let lines = csv.components(separatedBy: "\n").filter { !$0.isEmpty }
+        XCTAssertEqual(lines.count, 3)
+        XCTAssertTrue(csv.contains(",Blood Pressure Systolic,120,mmHg,"))
+        XCTAssertTrue(csv.contains(",Blood Pressure Diastolic,80,mmHg,"))
+    }
+
+    func testGenerateCombinedCSV_oxygenSaturation_formatsPercent() {
+        let sample = HKQuantitySample(
+            type: oxygenType,
+            quantity: HKQuantity(unit: .percent(), doubleValue: 0.985),
+            start: referenceDate,
+            end: referenceDate
+        )
+
+        let csv = CSVGenerator.generateCombinedCSV(
+            weightSamples: nil,
+            stepsSamples: nil,
+            glucoseSamples: nil,
+            labResults: nil,
+            vitalSamples: [.oxygenSaturation: [sample]],
+            weightUnit: .kilograms
+        )
+
+        XCTAssertTrue(csv.contains(",Oxygen Saturation,98.5,%,"))
+    }
+
+    func testGenerateCombinedCSV_bodyTemperature_usesSelectedUnit() {
+        let sample = HKQuantitySample(
+            type: bodyTemperatureType,
+            quantity: HKQuantity(unit: .degreeCelsius(), doubleValue: 37),
+            start: referenceDate,
+            end: referenceDate
+        )
+
+        let csv = CSVGenerator.generateCombinedCSV(
+            weightSamples: nil,
+            stepsSamples: nil,
+            glucoseSamples: nil,
+            labResults: nil,
+            vitalSamples: [.bodyTemperature: [sample]],
+            weightUnit: .kilograms,
+            temperatureUnit: .fahrenheit
+        )
+
+        XCTAssertTrue(csv.contains(",Body Temperature,98.6,°F,"))
     }
 
     func testGenerateCombinedCSV_a1cData_containsA1CRow() {

--- a/HealthExporterTests/ExportLogicTests.swift
+++ b/HealthExporterTests/ExportLogicTests.swift
@@ -37,6 +37,13 @@ final class ExportLogicTests: XCTestCase {
         ))
     }
 
+    func testExportEnabled_vitalsOnly_lastXDays() {
+        XCTAssertTrue(ExportLogic.isExportEnabled(
+            exportWeight: false, exportSteps: false, exportGlucose: false, hasSelectedLabs: false, hasSelectedVitals: true,
+            dateRangeOption: .lastXDays, startDate: now, endDate: now
+        ))
+    }
+
     func testExportEnabled_a1cOnly_specificDateRange_validRange() {
         let start = calendar.date(byAdding: .day, value: -7, to: now)!
         XCTAssertTrue(ExportLogic.isExportEnabled(
@@ -149,6 +156,25 @@ final class ExportLogicTests: XCTestCase {
         XCTAssertEqual(
             error?.localizedDescription,
             "Failed to fetch Lab Results data: lab failed"
+        )
+    }
+
+    func testFirstFetchError_vitalErrorUsesVitalsLabel() {
+        let vitalError = NSError(domain: "HKErrorDomain", code: 5, userInfo: [
+            NSLocalizedDescriptionKey: "vitals failed"
+        ])
+
+        let error = ExportLogic.firstFetchError(
+            weightError: nil,
+            stepsError: nil,
+            glucoseError: nil,
+            labError: nil,
+            vitalError: vitalError
+        )
+
+        XCTAssertEqual(
+            error?.localizedDescription,
+            "Failed to fetch Vitals data: vitals failed"
         )
     }
 
@@ -309,6 +335,24 @@ final class ExportLogicTests: XCTestCase {
         XCTAssertTrue(ExportLogic.hasAnyData(
             weightSamples: [sample], stepsSamples: nil,
             glucoseSamples: nil, labResults: nil
+        ))
+    }
+
+    func testHasAnyData_withVitalSamples_returnsTrue() {
+        let oxygenType = HKQuantityType.quantityType(forIdentifier: .oxygenSaturation)!
+        let sample = HKQuantitySample(
+            type: oxygenType,
+            quantity: HKQuantity(unit: .percent(), doubleValue: 0.98),
+            start: now,
+            end: now
+        )
+
+        XCTAssertTrue(ExportLogic.hasAnyData(
+            weightSamples: nil,
+            stepsSamples: nil,
+            glucoseSamples: nil,
+            labResults: nil,
+            vitalSamples: [.oxygenSaturation: [sample]]
         ))
     }
 

--- a/HealthExporterTests/ExportPreviewEstimateTests.swift
+++ b/HealthExporterTests/ExportPreviewEstimateTests.swift
@@ -7,6 +7,7 @@ final class ExportPreviewEstimateTests: XCTestCase {
     private let weightType = HKQuantityType.quantityType(forIdentifier: .bodyMass)!
     private let stepsType = HKQuantityType.quantityType(forIdentifier: .stepCount)!
     private let glucoseType = HKQuantityType.quantityType(forIdentifier: .bloodGlucose)!
+    private let oxygenType = HKQuantityType.quantityType(forIdentifier: .oxygenSaturation)!
     private let mgDlUnit = HKUnit.gramUnit(with: .milli).unitDivided(by: HKUnit.literUnit(with: .deci))
 
     private var referenceDate: Date {
@@ -81,12 +82,19 @@ final class ExportPreviewEstimateTests: XCTestCase {
             unit: "%",
             source: "Clinical Labs"
         )
+        let oxygenSample = HKQuantitySample(
+            type: oxygenType,
+            quantity: HKQuantity(unit: .percent(), doubleValue: 0.98),
+            start: referenceDate.addingTimeInterval(240),
+            end: referenceDate.addingTimeInterval(240)
+        )
 
         let estimate = CSVGenerator.makePreviewEstimate(
             weightSamples: [weightSample],
             stepsSamples: [stepsSample],
             glucoseSamples: [glucoseSample],
             labResults: [labSample],
+            vitalSamples: [.oxygenSaturation: [oxygenSample]],
             weightUnit: .pounds,
             dateFormat: .yyyyMMddHHmmss
         )
@@ -95,11 +103,12 @@ final class ExportPreviewEstimateTests: XCTestCase {
             stepsSamples: [stepsSample],
             glucoseSamples: [glucoseSample],
             labResults: [labSample],
+            vitalSamples: [.oxygenSaturation: [oxygenSample]],
             weightUnit: .pounds,
             dateFormat: .yyyyMMddHHmmss
         )
 
-        XCTAssertEqual(estimate.rowCount, 4)
+        XCTAssertEqual(estimate.rowCount, 5)
         XCTAssertEqual(estimate.estimatedByteCount, csv.utf8.count)
     }
 }

--- a/HealthExporterTests/HealthKitQueryHelpersTests.swift
+++ b/HealthExporterTests/HealthKitQueryHelpersTests.swift
@@ -63,6 +63,22 @@ final class HealthKitQueryHelpersTests: XCTestCase {
         }
     }
 
+    func testReadTypes_withVitals_containsSelectedVitalQuantityTypes() {
+        let types = HealthKitQueryHelpers.readTypes(
+            includeLabs: false,
+            vitalMetrics: [.bloodPressure, .oxygenSaturation]
+        )
+
+        let systolic = HKQuantityType.quantityType(forIdentifier: .bloodPressureSystolic)!
+        let diastolic = HKQuantityType.quantityType(forIdentifier: .bloodPressureDiastolic)!
+        let oxygen = HKQuantityType.quantityType(forIdentifier: .oxygenSaturation)!
+
+        XCTAssertTrue(types.contains(systolic))
+        XCTAssertTrue(types.contains(diastolic))
+        XCTAssertTrue(types.contains(oxygen))
+        XCTAssertEqual(types.count, 6)
+    }
+
     // MARK: - dayAlignedRange
 
     func testDayAlignedRange_alignsToStartOfDay() {

--- a/HealthExporterTests/HealthMetricConfigTests.swift
+++ b/HealthExporterTests/HealthMetricConfigTests.swift
@@ -30,4 +30,46 @@ final class HealthMetricConfigTests: XCTestCase {
         XCTAssertEqual(LOINCCode.ldlCholesterolDirect, "2089-1")
         XCTAssertEqual(LOINCCode.triglycerides, "2571-8")
     }
+
+    func testLOINCCode_cbcConstants_areCorrect() {
+        XCTAssertEqual(LOINCCode.whiteBloodCellCount, "6690-2")
+        XCTAssertEqual(LOINCCode.redBloodCellCount, "789-8")
+        XCTAssertEqual(LOINCCode.hemoglobin, "718-7")
+        XCTAssertEqual(LOINCCode.hematocrit, "4544-3")
+        XCTAssertEqual(LOINCCode.platelets, "777-3")
+        XCTAssertEqual(LOINCCode.meanCorpuscularVolume, "787-2")
+        XCTAssertEqual(LOINCCode.meanCorpuscularHemoglobin, "785-6")
+        XCTAssertEqual(LOINCCode.meanCorpuscularHemoglobinConcentration, "786-4")
+        XCTAssertEqual(LOINCCode.redCellDistributionWidth, "788-0")
+    }
+
+    func testLOINCCode_cmpAndThyroidConstants_areCorrect() {
+        XCTAssertEqual(LOINCCode.fastingGlucose, "1558-6")
+        XCTAssertEqual(LOINCCode.bloodUreaNitrogen, "3094-0")
+        XCTAssertEqual(LOINCCode.creatinine, "2160-0")
+        XCTAssertEqual(LOINCCode.estimatedGlomerularFiltrationRate, "33914-3")
+        XCTAssertEqual(LOINCCode.sodium, "2951-2")
+        XCTAssertEqual(LOINCCode.potassium, "2823-3")
+        XCTAssertEqual(LOINCCode.chloride, "2075-0")
+        XCTAssertEqual(LOINCCode.carbonDioxideBicarbonate, "2028-9")
+        XCTAssertEqual(LOINCCode.calcium, "17861-6")
+        XCTAssertEqual(LOINCCode.totalProtein, "2885-2")
+        XCTAssertEqual(LOINCCode.albumin, "1751-7")
+        XCTAssertEqual(LOINCCode.bilirubinTotal, "1975-2")
+        XCTAssertEqual(LOINCCode.alanineAminotransferase, "1742-6")
+        XCTAssertEqual(LOINCCode.aspartateAminotransferase, "1920-8")
+        XCTAssertEqual(LOINCCode.alkalinePhosphatase, "6768-6")
+        XCTAssertEqual(LOINCCode.thyroidStimulatingHormone, "3016-3")
+        XCTAssertEqual(LOINCCode.freeT4, "3024-7")
+        XCTAssertEqual(LOINCCode.freeT3, "3051-0")
+    }
+
+    func testLOINCCode_otherLabConstants_areCorrect() {
+        XCTAssertEqual(LOINCCode.vitaminD25Hydroxy, "1989-3")
+        XCTAssertEqual(LOINCCode.vitaminB12, "2132-9")
+        XCTAssertEqual(LOINCCode.ferritin, "2276-4")
+        XCTAssertEqual(LOINCCode.iron, "2498-4")
+        XCTAssertEqual(LOINCCode.totalIronBindingCapacity, "2500-7")
+        XCTAssertEqual(LOINCCode.highSensitivityCRP, "30522-7")
+    }
 }

--- a/HealthExporterTests/HealthMetricConfigTests.swift
+++ b/HealthExporterTests/HealthMetricConfigTests.swift
@@ -23,4 +23,11 @@ final class HealthMetricConfigTests: XCTestCase {
         XCTAssertEqual(LOINCCode.hemoglobinA1C, "4548-4",
             "LOINC code for Hemoglobin A1C should be 4548-4")
     }
+
+    func testLOINCCode_lipidPanelConstants_areCorrect() {
+        XCTAssertEqual(LOINCCode.totalCholesterol, "2093-3")
+        XCTAssertEqual(LOINCCode.hdlCholesterol, "2085-9")
+        XCTAssertEqual(LOINCCode.ldlCholesterolDirect, "2089-1")
+        XCTAssertEqual(LOINCCode.triglycerides, "2571-8")
+    }
 }

--- a/HealthExporterTests/LabMetricRegistryTests.swift
+++ b/HealthExporterTests/LabMetricRegistryTests.swift
@@ -57,9 +57,25 @@ final class LabMetricRegistryTests: XCTestCase {
         XCTAssertTrue(others.contains { $0.loincCode == LOINCCode.hemoglobinA1C })
     }
 
-    func testRegistry_metricsForPanel_lipid_isInitiallyEmpty() {
-        // Lipid/CBC/CMP/Thyroid panels are scaffolded for future labs but seeded
-        // empty in this refactor — only A1C exists today.
-        XCTAssertTrue(LabMetricRegistry.metrics(in: .lipid).isEmpty)
+    func testRegistry_metricsForPanel_lipid_includesExpectedMetrics() {
+        let lipids = LabMetricRegistry.metrics(in: .lipid)
+        let expectedCodes: Set<String> = [
+            LOINCCode.totalCholesterol,
+            LOINCCode.hdlCholesterol,
+            LOINCCode.ldlCholesterolDirect,
+            LOINCCode.triglycerides
+        ]
+
+        XCTAssertEqual(Set(lipids.map(\.loincCode)), expectedCodes)
+        XCTAssertTrue(lipids.allSatisfy { $0.group == .lipid })
+        XCTAssertTrue(lipids.allSatisfy { $0.valuePrecision == 0 })
+    }
+
+    func testRegistry_lipidMetricsHaveExpectedNames() {
+        let metricsByCode = Dictionary(uniqueKeysWithValues: LabMetricRegistry.metrics(in: .lipid).map { ($0.loincCode, $0.name) })
+        XCTAssertEqual(metricsByCode[LOINCCode.totalCholesterol], "Total Cholesterol")
+        XCTAssertEqual(metricsByCode[LOINCCode.hdlCholesterol], "HDL Cholesterol")
+        XCTAssertEqual(metricsByCode[LOINCCode.ldlCholesterolDirect], "LDL Cholesterol")
+        XCTAssertEqual(metricsByCode[LOINCCode.triglycerides], "Triglycerides")
     }
 }

--- a/HealthExporterTests/LabMetricRegistryTests.swift
+++ b/HealthExporterTests/LabMetricRegistryTests.swift
@@ -14,6 +14,14 @@ final class LabMetricRegistryTests: XCTestCase {
         XCTAssertEqual(cases, [.lipid, .cbc, .cmp, .thyroid, .other])
     }
 
+    func testLabPanel_displayNamesMatchExportSections() {
+        XCTAssertEqual(LabPanel.lipid.displayName, "Lipid panel")
+        XCTAssertEqual(LabPanel.cbc.displayName, "CBC")
+        XCTAssertEqual(LabPanel.cmp.displayName, "CMP / BMP")
+        XCTAssertEqual(LabPanel.thyroid.displayName, "Thyroid")
+        XCTAssertEqual(LabPanel.other.displayName, "Other")
+    }
+
     // MARK: - LabMetric
 
     func testLabMetric_idEqualsLoincCode() {
@@ -77,5 +85,75 @@ final class LabMetricRegistryTests: XCTestCase {
         XCTAssertEqual(metricsByCode[LOINCCode.hdlCholesterol], "HDL Cholesterol")
         XCTAssertEqual(metricsByCode[LOINCCode.ldlCholesterolDirect], "LDL Cholesterol")
         XCTAssertEqual(metricsByCode[LOINCCode.triglycerides], "Triglycerides")
+    }
+
+    func testRegistry_metricsForPanel_cbc_includesExpectedMetrics() {
+        let cbc = LabMetricRegistry.metrics(in: .cbc)
+        let expectedCodes: Set<String> = [
+            LOINCCode.whiteBloodCellCount,
+            LOINCCode.redBloodCellCount,
+            LOINCCode.hemoglobin,
+            LOINCCode.hematocrit,
+            LOINCCode.platelets,
+            LOINCCode.meanCorpuscularVolume,
+            LOINCCode.meanCorpuscularHemoglobin,
+            LOINCCode.meanCorpuscularHemoglobinConcentration,
+            LOINCCode.redCellDistributionWidth
+        ]
+
+        XCTAssertEqual(Set(cbc.map(\.loincCode)), expectedCodes)
+        XCTAssertTrue(cbc.allSatisfy { $0.group == .cbc })
+    }
+
+    func testRegistry_metricsForPanel_cmp_includesExpectedMetrics() {
+        let cmp = LabMetricRegistry.metrics(in: .cmp)
+        let expectedCodes: Set<String> = [
+            LOINCCode.fastingGlucose,
+            LOINCCode.bloodUreaNitrogen,
+            LOINCCode.creatinine,
+            LOINCCode.estimatedGlomerularFiltrationRate,
+            LOINCCode.sodium,
+            LOINCCode.potassium,
+            LOINCCode.chloride,
+            LOINCCode.carbonDioxideBicarbonate,
+            LOINCCode.calcium,
+            LOINCCode.totalProtein,
+            LOINCCode.albumin,
+            LOINCCode.bilirubinTotal,
+            LOINCCode.alanineAminotransferase,
+            LOINCCode.aspartateAminotransferase,
+            LOINCCode.alkalinePhosphatase
+        ]
+
+        XCTAssertEqual(Set(cmp.map(\.loincCode)), expectedCodes)
+        XCTAssertTrue(cmp.allSatisfy { $0.group == .cmp })
+    }
+
+    func testRegistry_metricsForPanel_thyroid_includesExpectedMetrics() {
+        let thyroid = LabMetricRegistry.metrics(in: .thyroid)
+        let expectedCodes: Set<String> = [
+            LOINCCode.thyroidStimulatingHormone,
+            LOINCCode.freeT4,
+            LOINCCode.freeT3
+        ]
+
+        XCTAssertEqual(Set(thyroid.map(\.loincCode)), expectedCodes)
+        XCTAssertTrue(thyroid.allSatisfy { $0.group == .thyroid })
+    }
+
+    func testRegistry_metricsForPanel_other_includesExpectedTrackedLabs() {
+        let others = LabMetricRegistry.metrics(in: .other)
+        let expectedCodes: Set<String> = [
+            LOINCCode.hemoglobinA1C,
+            LOINCCode.vitaminD25Hydroxy,
+            LOINCCode.vitaminB12,
+            LOINCCode.ferritin,
+            LOINCCode.iron,
+            LOINCCode.totalIronBindingCapacity,
+            LOINCCode.highSensitivityCRP
+        ]
+
+        XCTAssertEqual(Set(others.map(\.loincCode)), expectedCodes)
+        XCTAssertTrue(others.allSatisfy { $0.group == .other })
     }
 }

--- a/HealthExporterTests/SettingsManagerTests.swift
+++ b/HealthExporterTests/SettingsManagerTests.swift
@@ -174,6 +174,12 @@ final class SettingsManagerTests: XCTestCase {
         XCTAssertTrue(raw.isEmpty)
     }
 
+    func testDefaultSelectedVitalMetrics_whenKeyMissing_isEmpty() {
+        let defaults = makeDefaults()
+        let raw = defaults.array(forKey: "selectedVitalMetrics") as? [String] ?? []
+        XCTAssertTrue(raw.isEmpty)
+    }
+
     func testReadsPersistedSelectedLabPanels() {
         let defaults = makeDefaults()
         defaults.set([LabPanel.lipid.rawValue, LabPanel.thyroid.rawValue], forKey: "selectedLabPanels")
@@ -187,6 +193,17 @@ final class SettingsManagerTests: XCTestCase {
         defaults.set(["4548-4", "2093-3"], forKey: "favoriteLabCodes")
         let codes = Set(defaults.array(forKey: "favoriteLabCodes") as? [String] ?? [])
         XCTAssertEqual(codes, ["4548-4", "2093-3"])
+    }
+
+    func testReadsPersistedSelectedVitalMetrics() {
+        let defaults = makeDefaults()
+        defaults.set(
+            [VitalMetric.bloodPressure.rawValue, VitalMetric.restingHeartRate.rawValue],
+            forKey: "selectedVitalMetrics"
+        )
+        let raw = defaults.array(forKey: "selectedVitalMetrics") as? [String] ?? []
+        let metrics = Set(raw.compactMap(VitalMetric.init(rawValue:)))
+        XCTAssertEqual(metrics, [.bloodPressure, .restingHeartRate])
     }
 
     // MARK: - Legacy exportA1C migration

--- a/HealthExporterTests/VitalMetricRegistryTests.swift
+++ b/HealthExporterTests/VitalMetricRegistryTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+import HealthKit
+@testable import HealthExporter
+
+final class VitalMetricRegistryTests: XCTestCase {
+
+    func testVitalMetric_containsExpectedCases() {
+        XCTAssertEqual(
+            Set(VitalMetric.allCases),
+            Set([
+                .bloodPressure,
+                .restingHeartRate,
+                .heartRateVariabilitySDNN,
+                .oxygenSaturation,
+                .respiratoryRate,
+                .bodyTemperature
+            ])
+        )
+    }
+
+    func testBloodPressureExpandsToSystolicAndDiastolicComponents() {
+        XCTAssertEqual(VitalMetric.bloodPressure.components, [.bloodPressureSystolic, .bloodPressureDiastolic])
+    }
+
+    func testVitalComponentsHaveUniqueRawValues() {
+        let rawValues = VitalMetricComponent.allCases.map(\.rawValue)
+        XCTAssertEqual(Set(rawValues).count, rawValues.count)
+    }
+
+    func testVitalComponentHealthKitIdentifiers() {
+        XCTAssertEqual(VitalMetricComponent.bloodPressureSystolic.healthKitIdentifier, .bloodPressureSystolic)
+        XCTAssertEqual(VitalMetricComponent.bloodPressureDiastolic.healthKitIdentifier, .bloodPressureDiastolic)
+        XCTAssertEqual(VitalMetricComponent.restingHeartRate.healthKitIdentifier, .restingHeartRate)
+        XCTAssertEqual(VitalMetricComponent.heartRateVariabilitySDNN.healthKitIdentifier, .heartRateVariabilitySDNN)
+        XCTAssertEqual(VitalMetricComponent.oxygenSaturation.healthKitIdentifier, .oxygenSaturation)
+        XCTAssertEqual(VitalMetricComponent.respiratoryRate.healthKitIdentifier, .respiratoryRate)
+        XCTAssertEqual(VitalMetricComponent.bodyTemperature.healthKitIdentifier, .bodyTemperature)
+    }
+
+    func testOxygenSaturationConvertsHealthKitFractionToPercent() {
+        let quantity = HKQuantity(unit: .percent(), doubleValue: 0.985)
+        let result = VitalMetricComponent.oxygenSaturation.valueAndUnit(from: quantity, temperatureUnit: .fahrenheit)
+
+        XCTAssertEqual(result.value, 98.5, accuracy: 0.0001)
+        XCTAssertEqual(result.unit, "%")
+    }
+
+    func testBodyTemperatureUsesSelectedUnit() {
+        let quantity = HKQuantity(unit: .degreeCelsius(), doubleValue: 37.0)
+        let fahrenheit = VitalMetricComponent.bodyTemperature.valueAndUnit(from: quantity, temperatureUnit: .fahrenheit)
+        let celsius = VitalMetricComponent.bodyTemperature.valueAndUnit(from: quantity, temperatureUnit: .celsius)
+
+        XCTAssertEqual(fahrenheit.value, 98.6, accuracy: 0.01)
+        XCTAssertEqual(fahrenheit.unit, "°F")
+        XCTAssertEqual(celsius.value, 37.0, accuracy: 0.01)
+        XCTAssertEqual(celsius.unit, "°C")
+    }
+}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A privacy-focused iOS app that exports Apple HealthKit data to CSV files. All da
 ## Features
 
 - **Privacy-first design**: All processing on-device, no analytics, no tracking, no accounts
-- **Multiple health metrics**: Export Weight, Steps, Blood Glucose (mg/dL), and selected clinical lab results including Hemoglobin A1C and lipid panel labs
+- **Multiple health metrics**: Export Weight, Steps, Blood Glucose (mg/dL), selected clinical lab panels, and selected vitals
 - **Flexible date ranges**: Last X days, last X records, custom date range, or all data
 - **Unit preferences**: Configure weight units (kg/lbs), temperature (°C/°F), and distance/speed (metric/imperial); defaults to US units (Fahrenheit, lbs, imperial)
 - **Selectable date format**: Choose from 5 date formats including ISO8601 (UTC), `yyyy-MM-dd HH:mm:ss`, `MM/dd/yyyy HH:mm:ss`, and more
@@ -47,7 +47,7 @@ A privacy-focused iOS app that exports Apple HealthKit data to CSV files. All da
 1. Launch the app (splash screen displays briefly)
 2. (Optional) Tap the gear icon to configure unit preferences or view the privacy policy
 3. Tap "Next" to go to the data selection screen
-4. Select metrics to export (Weight, Steps, Blood Glucose, lab favorites, or lab panels)
+4. Select metrics to export (Weight, Steps, Blood Glucose, lab sections, or vitals)
 5. Choose a date range option (last X days, last X records, date range, or all data)
 6. Tap "Save..." to save to Files
 
@@ -58,8 +58,8 @@ The exported CSV includes the following columns:
 | Column | Description |
 |--------|-------------|
 | **Date** | Timestamp in user-selected format (see below) |
-| **Metric** | Type of measurement (Weight, Steps, Blood Glucose, Hemoglobin A1C, Total Cholesterol, HDL Cholesterol, LDL Cholesterol, Triglycerides) |
-| **Value** | Numeric value (weight/A1C: 2 decimal places; glucose/steps/lipid labs: integer) |
+| **Metric** | Type of measurement (Weight, Steps, Blood Glucose, lab result, or vital sign) |
+| **Value** | Numeric value with metric-specific precision |
 | **Unit** | Unit of measurement (kg, lbs, steps, mg/dL, %, etc.) |
 | **Source** | The app or device that recorded the data (e.g., Withings, Apple Watch) |
 
@@ -81,6 +81,9 @@ Date,Metric,Value,Unit,Source
 2026-01-09 14:30:00,Blood Glucose,145,mg/dL,MyFitnessPal
 2026-01-15 14:30:00,Hemoglobin A1C,7.50,%,Apple Health
 2026-01-15 14:31:00,Total Cholesterol,184,mg/dL,Apple Health
+2026-01-15 14:32:00,Blood Pressure Systolic,120,mmHg,Apple Health
+2026-01-15 14:32:00,Blood Pressure Diastolic,80,mmHg,Apple Health
+2026-01-15 14:33:00,Oxygen Saturation,98.5,%,Apple Health
 ```
 
 Data can be sorted ascending (oldest first) or descending (newest first) within each metric type. Filename format: `HealthExporter_YYYY-MM-DD_HHMMSS.csv`.
@@ -105,7 +108,7 @@ Unit tests run automatically in GitHub Actions CI on every push and PR. See [doc
 
 ### Lab Testing Status
 
-Hemoglobin A1C export has been **verified working end-to-end** on a physical device with Clinical Health Records enabled. Lipid panel export uses the same registry-driven clinical-records pipeline and is covered by unit tests; validate new lab records on a physical device before release. See [docs/a1c/](docs/a1c/) for implementation details.
+Hemoglobin A1C export has been **verified working end-to-end** on a physical device with Clinical Health Records enabled. Additional lab panels use the same registry-driven clinical-records pipeline and are covered by unit tests; validate new lab records on a physical device before release. Vitals use HealthKit quantity samples and should also be verified on device before release. See [docs/a1c/](docs/a1c/) for lab implementation details.
 
 ## Releases
 
@@ -146,7 +149,9 @@ HealthExporter/
 │       ├── SettingsView.swift           # Unit/format preferences & test data
 │       ├── PrivacyPolicyView.swift      # Privacy policy & disclaimer
 │       ├── HealthKitManager.swift       # HealthKit auth & data fetching
-│       ├── HealthMetricConfig.swift     # Central metric registry
+      │       ├── HealthMetricConfig.swift     # Base metric registry
+      │       ├── LabMetricRegistry.swift      # Clinical lab panel registry
+      │       ├── VitalMetricRegistry.swift    # HealthKit vital metric registry
 │       ├── HealthSampleTypes.swift      # Glucose, LOINC constants, FHIR parsing
 │       ├── CSVGenerator.swift           # CSV generation & unit conversion
 │       ├── CSVDocument.swift            # FileDocument for saving
@@ -174,7 +179,7 @@ HealthExporter/
 
 ## Privacy Policy
 
-*Last updated: March 2026*
+*Last updated: May 2026*
 
 ### Overview
 
@@ -187,7 +192,8 @@ HealthExporterCSV requests read-only access to the following Apple HealthKit dat
 - Weight
 - Step Count
 - Blood Glucose
-- Selected clinical lab results, such as Hemoglobin A1C and lipid panel labs
+- Selected clinical lab results, such as Hemoglobin A1C, lipid panel, CBC, CMP / BMP, thyroid, and other tracked labs
+- Selected vitals, such as blood pressure, resting heart rate, heart rate variability, oxygen saturation, respiratory rate, and body temperature
 
 You control exactly which data types to share through the Apple Health permissions dialog.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A privacy-focused iOS app that exports Apple HealthKit data to CSV files. All da
 ## Features
 
 - **Privacy-first design**: All processing on-device, no analytics, no tracking, no accounts
-- **Multiple health metrics**: Export Weight, Steps, Blood Glucose (mg/dL), and Hemoglobin A1C (%)
+- **Multiple health metrics**: Export Weight, Steps, Blood Glucose (mg/dL), and selected clinical lab results including Hemoglobin A1C and lipid panel labs
 - **Flexible date ranges**: Last X days, last X records, custom date range, or all data
 - **Unit preferences**: Configure weight units (kg/lbs), temperature (°C/°F), and distance/speed (metric/imperial); defaults to US units (Fahrenheit, lbs, imperial)
 - **Selectable date format**: Choose from 5 date formats including ISO8601 (UTC), `yyyy-MM-dd HH:mm:ss`, `MM/dd/yyyy HH:mm:ss`, and more
@@ -13,7 +13,7 @@ A privacy-focused iOS app that exports Apple HealthKit data to CSV files. All da
 - **CSV export**: Save directly to Files app via `.fileExporter()`
 - **Splash screen** with navigation to data selection and settings
 - **Settings persistence**: Unit preferences are automatically saved
-- **Clinical records support**: A1C export requires Clinical Health Records capability and permission
+- **Clinical records support**: Lab-result export requires Clinical Health Records capability and permission
 - **Memory-optimized**: Health data is cleared from memory immediately after export
 
 ## Screenshots
@@ -39,7 +39,7 @@ A privacy-focused iOS app that exports Apple HealthKit data to CSV files. All da
 
 1. Open `HealthExporter.xcodeproj` in Xcode
 2. Ensure HealthKit is enabled in Signing & Capabilities
-3. If using Hemoglobin A1C export, enable **Clinical Health Records** capability (see [A1C docs](docs/a1c/) for details)
+3. If using lab-result export, enable **Clinical Health Records** capability (see [lab result docs](docs/a1c/) for details)
 4. Build and run on a physical device (HealthKit has limited simulator support)
 
 ## Usage
@@ -47,7 +47,7 @@ A privacy-focused iOS app that exports Apple HealthKit data to CSV files. All da
 1. Launch the app (splash screen displays briefly)
 2. (Optional) Tap the gear icon to configure unit preferences or view the privacy policy
 3. Tap "Next" to go to the data selection screen
-4. Select metrics to export (Weight, Steps, Blood Glucose, A1C)
+4. Select metrics to export (Weight, Steps, Blood Glucose, lab favorites, or lab panels)
 5. Choose a date range option (last X days, last X records, date range, or all data)
 6. Tap "Save..." to save to Files
 
@@ -58,9 +58,9 @@ The exported CSV includes the following columns:
 | Column | Description |
 |--------|-------------|
 | **Date** | Timestamp in user-selected format (see below) |
-| **Metric** | Type of measurement (Weight, Steps, Blood Glucose, Hemoglobin A1C) |
-| **Value** | Numeric value (weight/A1C: 2 decimal places; glucose: integer; steps: integer) |
-| **Unit** | Unit of measurement (kg, lbs, steps, mg/dL, %) |
+| **Metric** | Type of measurement (Weight, Steps, Blood Glucose, Hemoglobin A1C, Total Cholesterol, HDL Cholesterol, LDL Cholesterol, Triglycerides) |
+| **Value** | Numeric value (weight/A1C: 2 decimal places; glucose/steps/lipid labs: integer) |
+| **Unit** | Unit of measurement (kg, lbs, steps, mg/dL, %, etc.) |
 | **Source** | The app or device that recorded the data (e.g., Withings, Apple Watch) |
 
 ### Date Format Options
@@ -80,6 +80,7 @@ Date,Metric,Value,Unit,Source
 2026-01-09 11:00:00,Steps,5432,steps,Apple Watch
 2026-01-09 14:30:00,Blood Glucose,145,mg/dL,MyFitnessPal
 2026-01-15 14:30:00,Hemoglobin A1C,7.50,%,Apple Health
+2026-01-15 14:31:00,Total Cholesterol,184,mg/dL,Apple Health
 ```
 
 Data can be sorted ascending (oldest first) or descending (newest first) within each metric type. Filename format: `HealthExporter_YYYY-MM-DD_HHMMSS.csv`.
@@ -89,7 +90,7 @@ Data can be sorted ascending (oldest first) or descending (newest first) within 
 - iOS 26+
 - Physical iOS device (for full HealthKit functionality)
 - HealthKit access permission
-- Clinical Health Records capability and user permission (for A1C export)
+- Clinical Health Records capability and user permission (for lab-result export)
 
 ## Testing
 
@@ -102,9 +103,9 @@ Unit tests run automatically in GitHub Actions CI on every push and PR. See [doc
 | `HealthMetricConfigTests.swift` | Metric availability, LOINC codes |
 | `GlucoseSampleTests.swift` | Blood glucose filtering (values >= 20 accepted, < 20 rejected) |
 
-### A1C Testing Status
+### Lab Testing Status
 
-Hemoglobin A1C export has been **verified working end-to-end** on a physical device with Clinical Health Records enabled. See [docs/a1c/](docs/a1c/) for implementation details.
+Hemoglobin A1C export has been **verified working end-to-end** on a physical device with Clinical Health Records enabled. Lipid panel export uses the same registry-driven clinical-records pipeline and is covered by unit tests; validate new lab records on a physical device before release. See [docs/a1c/](docs/a1c/) for implementation details.
 
 ## Releases
 
@@ -146,7 +147,7 @@ HealthExporter/
 │       ├── PrivacyPolicyView.swift      # Privacy policy & disclaimer
 │       ├── HealthKitManager.swift       # HealthKit auth & data fetching
 │       ├── HealthMetricConfig.swift     # Central metric registry
-│       ├── HealthSampleTypes.swift      # Glucose, A1C, FHIR parsing
+│       ├── HealthSampleTypes.swift      # Glucose, LOINC constants, FHIR parsing
 │       ├── CSVGenerator.swift           # CSV generation & unit conversion
 │       ├── CSVDocument.swift            # FileDocument for saving
 │       ├── SettingsManager.swift        # UserDefaults persistence
@@ -186,7 +187,7 @@ HealthExporterCSV requests read-only access to the following Apple HealthKit dat
 - Weight
 - Step Count
 - Blood Glucose
-- Hemoglobin A1C
+- Selected clinical lab results, such as Hemoglobin A1C and lipid panel labs
 
 You control exactly which data types to share through the Apple Health permissions dialog.
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -12,20 +12,21 @@ Tests live in `HealthExporterTests/` (sibling to the main `HealthExporter/` sour
 |------|--------------|
 | `A1CCSVBytePinningTests.swift` | Byte-identical A1C CSV rows: `%` and `mmol/mol` units, comma/quote CSV escaping, two-decimal precision, ascending sort |
 | `CSVDocumentTests.swift` | `CSVDocument` content storage, UTF-8 round-trip, invalid encoding detection |
-| `CSVGeneratorTests.swift` | CSV generation for weight, steps, glucose, lab results; unit conversion (kg→lbs); registry-driven precision; output formatting |
+| `CSVGeneratorTests.swift` | CSV generation for weight, steps, glucose, lab results, and vitals; unit conversion; registry-driven precision; output formatting |
 | `DateRangeOptionTests.swift` | `DateRangeOption` enum cases, raw values, `displayName` |
 | `DayRangeSummaryFormatterTests.swift` | Date range summary text formatting |
 | `ExportErrorTests.swift` | All `ExportError.errorDescription` branches with/without underlying errors |
-| `ExportLogicTests.swift` | Export enablement (including `hasSelectedLabs`), date range calculation, record limits, data availability, filename generation, `resolveLabMetrics` panel/favorite union and dedup |
+| `ExportLogicTests.swift` | Export enablement (including labs and vitals), date range calculation, record limits, data availability, filename generation, `resolveLabMetrics` panel/favorite union and dedup |
 | `ExportPreviewEstimateTests.swift` | Row count rounding, byte estimation, confirmation threshold |
 | `FHIRLabResultParserTests.swift` | FHIR JSON parsing — LOINC matching, missing fields, invalid data |
 | `GlucoseSampleTests.swift` | `GlucoseSampleMgDl` init — values ≥20 accepted, values <20 rejected |
-| `HealthKitQueryHelpersTests.swift` | Authorization type sets (with/without labs), day-aligned date ranges, `filterLabResultsByDateRange`, simulator-only test data helpers |
+| `HealthKitQueryHelpersTests.swift` | Authorization type sets (with/without labs and vitals), day-aligned date ranges, `filterLabResultsByDateRange`, simulator-only test data helpers |
 | `HealthMetricConfigTests.swift` | `HealthMetrics` static properties and `LOINCCode` constants |
 | `LabMetricRegistryTests.swift` | `LabPanel` cases, `LabMetric.id == loincCode`, registry uniqueness, lookup by LOINC, panel grouping |
 | `LabResultSampleTests.swift` | `LabResultSample` memberwise init, default empty source, FHIR init with known/unknown LOINC, missing observation handling |
 | `SettingsEnumTests.swift` | Raw values, displayName, dateFormat, isUTC for all settings enums |
-| `SettingsManagerTests.swift` | Default values, persisted reads (including `selectedLabPanels` / `favoriteLabCodes`), invalid raw value fallbacks, legacy `exportA1C` → favorites migration |
+| `SettingsManagerTests.swift` | Default values, persisted reads (including lab and vital selections), invalid raw value fallbacks, legacy `exportA1C` → favorites migration |
+| `VitalMetricRegistryTests.swift` | Vital metric cases, HealthKit identifiers, blood-pressure component expansion, unit conversion |
 
 ## Running Tests Locally
 
@@ -95,6 +96,7 @@ The following items **intentionally remain outside CI unit tests** and require m
 - Real HealthKit authorization dialogs (grant/deny/partial)
 - Authorization state persistence across app launches
 - Behavior when HealthKit is unavailable (e.g. iPad without HealthKit)
+- Real HealthKit vital samples, including blood-pressure pairs and oxygen saturation percentages
 
 ### Clinical Health Records
 - Real Clinical Health Records availability and entitlement

--- a/docs/a1c/IMPLEMENTATION_GUIDE.md
+++ b/docs/a1c/IMPLEMENTATION_GUIDE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Lab result export — including Hemoglobin A1C and lipid panel labs — is part of the current HealthExporter release. Users can opt into exporting Clinical Health Records lab results and the app will include matching records in the combined CSV output. The lab pipeline is registry-driven: adding a new lab requires only appending a `LabMetric` to `LabMetricRegistry.all`.
+Lab result export — including Hemoglobin A1C, lipid panel, CBC, CMP / BMP, thyroid, and other tracked labs — is part of the current HealthExporter release. Users can opt into exporting Clinical Health Records lab results and the app will include matching records in the combined CSV output. The lab pipeline is registry-driven: adding a new lab requires only appending a `LabMetric` to `LabMetricRegistry.all`.
 
 > Testing status: A1C export has been verified working end-to-end on a physical device with Clinical Health Records enabled. Byte-identical CSV output is pinned by `A1CCSVBytePinningTests`.
 
@@ -13,7 +13,7 @@ Lab result export — including Hemoglobin A1C and lipid panel labs — is part 
 - `LabMetricRegistry.swift` defines the metric registry
 - `LabPanel` groups metrics into logical panels (`lipid`, `cbc`, `cmp`, `thyroid`, `other`)
 - `LabMetric` describes a single lab observation: `name`, `loincCode` (also `id`), `group`, and `valuePrecision`
-- `LabMetricRegistry.all` is the single source of truth; current entries include Hemoglobin A1C plus Total Cholesterol, HDL Cholesterol, LDL Cholesterol, and Triglycerides
+- `LabMetricRegistry.all` is the single source of truth; current entries include Hemoglobin A1C, lipid panel, CBC, CMP / BMP, thyroid, and other tracked labs
 - Helpers: `LabMetricRegistry.metric(forLoincCode:)` and `LabMetricRegistry.metrics(in:)`
 
 ### Data Model
@@ -21,11 +21,11 @@ Lab result export — including Hemoglobin A1C and lipid panel labs — is part 
 - `HealthSampleTypes.swift` defines `LabResultSample`, the generic lab result row
 - `LabResultSample` carries `metricName`, `loincCode`, `effectiveDateTime`, `value`, `unit`, and `source`
 - Initializers parse FHIR JSON (`init?(fromFHIRData:loincCode:source:)`) or an `HKClinicalRecord` (`init?(from:loincCode:)`)
-- LOINC `4548-4` identifies Hemoglobin A1C; lipid LOINC constants (`2093-3`, `2085-9`, `2089-1`, `2571-8`) live alongside it in `LOINCCode`
+- LOINC constants live in `LOINCCode`; for example, `4548-4` identifies Hemoglobin A1C and `2093-3` identifies Total Cholesterol
 
 ### HealthKit Authorization
 
-- `HealthKitManager.requestAuthorization(includeLabs:completion:)` adds the clinical-records read type when any lab metric is selected
+- `HealthKitManager.requestAuthorization(includeLabs:vitalMetrics:completion:)` adds the clinical-records read type when any lab metric is selected
 - Production authorization is read-only; `toShare` is an empty set
 - The app targets iOS 26+, while the clinical-records code path is guarded with `#available(iOS 15.0, *)`
 
@@ -39,7 +39,7 @@ Lab result export — including Hemoglobin A1C and lipid panel labs — is part 
 
 - `SettingsManager` persists `selectedLabPanels: Set<LabPanel>` and `favoriteLabCodes: Set<String>` in `UserDefaults`
 - A one-time legacy migration seeds `favoriteLabCodes = ["4548-4"]` for upgrade installs that had `exportA1C == true`; the legacy boolean is no longer read after migration
-- `DataSelectionView` shows a "Lab Favorites" section (per-metric toggles bound to `favoriteLabCodes`) and a "Lab Panels" section (one toggle per `LabPanel` that has at least one registered metric)
+- `DataSelectionView` shows one section per `LabPanel`. Each section has a panel-level toggle plus per-metric toggles for fine-grained selection.
 - `ExportLogic.resolveLabMetrics(selectedPanels:favoriteCodes:registry:)` produces the deduplicated fetch list
 - `SettingsView` exposes simulator-only test data generation, but the write path is not part of the production export flow
 
@@ -47,7 +47,7 @@ Lab result export — including Hemoglobin A1C and lipid panel labs — is part 
 
 - `CSVGenerator.appendLabResultRows(to:samples:dateFormat:sortOrder:)` appends rows to the combined export
 - The metric label comes from `LabMetric.name` (e.g. `Hemoglobin A1C` or `Total Cholesterol`)
-- Per-metric precision comes from `LabMetric.valuePrecision`; A1C renders to 2 decimal places and lipid panel labs render as integers
+- Per-metric precision comes from `LabMetric.valuePrecision`
 
 ## Required Configuration
 
@@ -67,7 +67,7 @@ The Clinical Health Records usage string should clearly explain why the app need
 
 ## Data Flow
 
-1. User toggles favorites or panels in `DataSelectionView`
+1. User toggles lab sections or individual labs in `DataSelectionView`
 2. `ExportLogic.resolveLabMetrics` produces the deduplicated list of `LabMetric`s
 3. The app requests HealthKit read access; clinical records are included when the list is non-empty
 4. `HealthKitManager.fetchLabResults` runs a single clinical-records query

--- a/docs/a1c/IMPLEMENTATION_GUIDE.md
+++ b/docs/a1c/IMPLEMENTATION_GUIDE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Lab result export — including Hemoglobin A1C — is part of the current HealthExporter release. Users can opt into exporting Clinical Health Records lab results and the app will include matching records in the combined CSV output. The lab pipeline is registry-driven: adding a new lab requires only appending a `LabMetric` to `LabMetricRegistry.all`.
+Lab result export — including Hemoglobin A1C and lipid panel labs — is part of the current HealthExporter release. Users can opt into exporting Clinical Health Records lab results and the app will include matching records in the combined CSV output. The lab pipeline is registry-driven: adding a new lab requires only appending a `LabMetric` to `LabMetricRegistry.all`.
 
 > Testing status: A1C export has been verified working end-to-end on a physical device with Clinical Health Records enabled. Byte-identical CSV output is pinned by `A1CCSVBytePinningTests`.
 
@@ -13,7 +13,7 @@ Lab result export — including Hemoglobin A1C — is part of the current Health
 - `LabMetricRegistry.swift` defines the metric registry
 - `LabPanel` groups metrics into logical panels (`lipid`, `cbc`, `cmp`, `thyroid`, `other`)
 - `LabMetric` describes a single lab observation: `name`, `loincCode` (also `id`), `group`, and `valuePrecision`
-- `LabMetricRegistry.all` is the single source of truth; Hemoglobin A1C is currently the only registered entry
+- `LabMetricRegistry.all` is the single source of truth; current entries include Hemoglobin A1C plus Total Cholesterol, HDL Cholesterol, LDL Cholesterol, and Triglycerides
 - Helpers: `LabMetricRegistry.metric(forLoincCode:)` and `LabMetricRegistry.metrics(in:)`
 
 ### Data Model
@@ -21,7 +21,7 @@ Lab result export — including Hemoglobin A1C — is part of the current Health
 - `HealthSampleTypes.swift` defines `LabResultSample`, the generic lab result row
 - `LabResultSample` carries `metricName`, `loincCode`, `effectiveDateTime`, `value`, `unit`, and `source`
 - Initializers parse FHIR JSON (`init?(fromFHIRData:loincCode:source:)`) or an `HKClinicalRecord` (`init?(from:loincCode:)`)
-- LOINC `4548-4` identifies Hemoglobin A1C; new LOINC constants live alongside it in `LOINCCode`
+- LOINC `4548-4` identifies Hemoglobin A1C; lipid LOINC constants (`2093-3`, `2085-9`, `2089-1`, `2571-8`) live alongside it in `LOINCCode`
 
 ### HealthKit Authorization
 
@@ -46,8 +46,8 @@ Lab result export — including Hemoglobin A1C — is part of the current Health
 ### CSV Output
 
 - `CSVGenerator.appendLabResultRows(to:samples:dateFormat:sortOrder:)` appends rows to the combined export
-- The metric label comes from `LabMetric.name` (e.g. `Hemoglobin A1C`)
-- Per-metric precision comes from `LabMetric.valuePrecision`; A1C still renders to 2 decimal places
+- The metric label comes from `LabMetric.name` (e.g. `Hemoglobin A1C` or `Total Cholesterol`)
+- Per-metric precision comes from `LabMetric.valuePrecision`; A1C renders to 2 decimal places and lipid panel labs render as integers
 
 ## Required Configuration
 

--- a/docs/a1c/QUICK_REFERENCE.md
+++ b/docs/a1c/QUICK_REFERENCE.md
@@ -5,7 +5,7 @@
 ## What It Does
 
 - Exports lab result values from Apple Health Clinical Records
-- Each metric is identified by its LOINC code (`4548-4` for Hemoglobin A1C)
+- Each metric is identified by its LOINC code (`4548-4` for Hemoglobin A1C; lipid panel codes `2093-3`, `2085-9`, `2089-1`, `2571-8`)
 - Includes matching lab rows in the same CSV as weight, steps, and glucose
 
 ## Key Files
@@ -49,6 +49,7 @@ Also make sure the target has HealthKit and Clinical Health Records capabilities
 ```csv
 Date,Metric,Value,Unit,Source
 2026-01-15 14:30:00,Hemoglobin A1C,7.50,%,Apple Health
+2026-01-15 14:31:00,Total Cholesterol,184,mg/dL,Apple Health
 ```
 
 ## Adding a New Lab
@@ -60,5 +61,5 @@ Date,Metric,Value,Unit,Source
 ## Notes
 
 - No labs are selected by default
-- Per-metric value precision comes from `LabMetric.valuePrecision`; A1C still renders to 2 decimal places
+- Per-metric value precision comes from `LabMetric.valuePrecision`; A1C renders to 2 decimal places and lipid panel labs render as integers
 - Existing export metrics are unaffected

--- a/docs/a1c/QUICK_REFERENCE.md
+++ b/docs/a1c/QUICK_REFERENCE.md
@@ -5,17 +5,17 @@
 ## What It Does
 
 - Exports lab result values from Apple Health Clinical Records
-- Each metric is identified by its LOINC code (`4548-4` for Hemoglobin A1C; lipid panel codes `2093-3`, `2085-9`, `2089-1`, `2571-8`)
+- Each metric is identified by its LOINC code (`4548-4` for Hemoglobin A1C; additional supported panels include lipid, CBC, CMP / BMP, thyroid, and other tracked labs)
 - Includes matching lab rows in the same CSV as weight, steps, and glucose
 
 ## Key Files
 
 - `LabMetricRegistry.swift` for `LabPanel`, `LabMetric`, and `LabMetricRegistry.all`
 - `HealthSampleTypes.swift` for `LabResultSample`, FHIR parsing, and `LOINCCode` constants
-- `HealthKitManager.swift` for `requestAuthorization(includeLabs:completion:)` and `fetchLabResults(metrics:dateRange:limit:completion:)`
+- `HealthKitManager.swift` for `requestAuthorization(includeLabs:vitalMetrics:completion:)` and `fetchLabResults(metrics:dateRange:limit:completion:)`
 - `SettingsManager.swift` for `selectedLabPanels` and `favoriteLabCodes` (with one-time `exportA1C` migration)
 - `ExportLogic.swift` for `resolveLabMetrics(selectedPanels:favoriteCodes:registry:)`
-- `DataSelectionView.swift` for the "Lab Favorites" / "Lab Panels" toggles and the export flow
+- `DataSelectionView.swift` for lab section toggles and the export flow
 - `CSVGenerator.swift` for `appendLabResultRows(to:samples:dateFormat:sortOrder:)`
 
 ## Required Setup
@@ -37,7 +37,7 @@ Also make sure the target has HealthKit and Clinical Health Records capabilities
 
 ## Export Flow
 
-1. User toggles favorites or panels in the export screen
+1. User toggles lab sections or individual labs in the export screen
 2. `ExportLogic.resolveLabMetrics` builds the deduplicated `[LabMetric]` fetch list
 3. App requests HealthKit read access (clinical records included when labs are selected)
 4. `fetchLabResults` runs a single clinical-records query and parses every matching LOINC into a `LabResultSample`
@@ -61,5 +61,5 @@ Date,Metric,Value,Unit,Source
 ## Notes
 
 - No labs are selected by default
-- Per-metric value precision comes from `LabMetric.valuePrecision`; A1C renders to 2 decimal places and lipid panel labs render as integers
+- Per-metric value precision comes from `LabMetric.valuePrecision`
 - Existing export metrics are unaffected

--- a/docs/app-store-review.md
+++ b/docs/app-store-review.md
@@ -10,7 +10,7 @@ This note tracks the current App Store review posture for the `2.4.6` submission
 ## Confirmed
 
 - Production HealthKit access is read-only: `requestAuthorization(toShare: Set(), read: ...)`.
-- Clinical Health Records are only requested when A1C export is enabled.
+- Clinical Health Records are only requested when selected lab-result export requires them.
 - Simulator-only test data generation is gated behind `#if targetEnvironment(simulator)`.
 - The current build settings include the required HealthKit and Clinical Health Records usage strings.
 - The full unit test suite passes locally on the simulator.
@@ -19,7 +19,7 @@ This note tracks the current App Store review posture for the `2.4.6` submission
 
 - Export errors should distinguish HealthKit query failures from a genuinely empty result set.
 - `Last X Days` should be clarified or corrected so the date window matches the label.
-- A1C date filtering should be pushed down into the query path instead of filtering after fetch.
+- Lab-result date filtering should be pushed down into the query path instead of filtering after fetch.
 - The testing guide should use a collision-resistant simulator destination.
 
 ## Notes

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -6,7 +6,7 @@ permalink: /privacy-policy/
 
 # Privacy Policy — HealthExporterCSV
 
-**Last updated:** March 2026
+**Last updated:** May 2026
 
 ## Overview
 
@@ -19,7 +19,8 @@ HealthExporterCSV requests read-only access to the following Apple HealthKit dat
 - Weight
 - Step Count
 - Blood Glucose
-- Selected clinical lab results, such as Hemoglobin A1C and lipid panel labs
+- Selected clinical lab results, such as Hemoglobin A1C, lipid panel, CBC, CMP / BMP, thyroid, and other tracked labs
+- Selected vitals, such as blood pressure, resting heart rate, heart rate variability, oxygen saturation, respiratory rate, and body temperature
 
 You control exactly which data types to share through the Apple Health permissions dialog.
 

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -19,7 +19,7 @@ HealthExporterCSV requests read-only access to the following Apple HealthKit dat
 - Weight
 - Step Count
 - Blood Glucose
-- Hemoglobin A1C
+- Selected clinical lab results, such as Hemoglobin A1C and lipid panel labs
 
 You control exactly which data types to share through the Apple Health permissions dialog.
 

--- a/docs/roadmap/future-export-metrics.md
+++ b/docs/roadmap/future-export-metrics.md
@@ -9,7 +9,8 @@ The current app exports:
 - Weight (`HKQuantityTypeIdentifierBodyMass`)
 - Steps (`HKQuantityTypeIdentifierStepCount`)
 - Blood Glucose (`HKQuantityTypeIdentifierBloodGlucose`)
-- Hemoglobin A1C (`HKClinicalTypeIdentifierLabResultRecord`, filtered to LOINC `4548-4`)
+- Selected lab panels from Clinical Health Records, including Hemoglobin A1C, lipid panel, CBC, CMP / BMP, thyroid, and other tracked labs
+- Selected vitals: blood pressure, resting heart rate, heart rate variability (SDNN), oxygen saturation, respiratory rate, and body temperature
 
 The list below is based on a review of a full Apple Health export dump from a real iPhone backup (`~/Dropbox/apple_health_export`). The goal is to prioritize exports that are both useful to users and compatible with the app's CSV-first workflow.
 
@@ -46,14 +47,14 @@ The dump also contains:
 
 ### Cardio and recovery
 
-Strong near-term candidates with broad user appeal:
+Strong candidates with broad user appeal:
 
 - Heart Rate (`HKQuantityTypeIdentifierHeartRate`)
-- Resting Heart Rate (`HKQuantityTypeIdentifierRestingHeartRate`)
+- Resting Heart Rate (`HKQuantityTypeIdentifierRestingHeartRate`) — implemented
 - Walking Heart Rate Average (`HKQuantityTypeIdentifierWalkingHeartRateAverage`)
-- Heart Rate Variability (SDNN) (`HKQuantityTypeIdentifierHeartRateVariabilitySDNN`)
-- Respiratory Rate (`HKQuantityTypeIdentifierRespiratoryRate`)
-- Oxygen Saturation (`HKQuantityTypeIdentifierOxygenSaturation`)
+- Heart Rate Variability (SDNN) (`HKQuantityTypeIdentifierHeartRateVariabilitySDNN`) — implemented
+- Respiratory Rate (`HKQuantityTypeIdentifierRespiratoryRate`) — implemented
+- Oxygen Saturation (`HKQuantityTypeIdentifierOxygenSaturation`) — implemented
 - VO2 Max (`HKQuantityTypeIdentifierVO2Max`)
 - Heart Rate Recovery (`HKQuantityTypeIdentifierHeartRateRecoveryOneMinute`)
 
@@ -206,7 +207,7 @@ Beyond A1C, the sampled export includes:
 
 Potential future directions:
 
-- Generic lab-result export from clinical records
+- Additional clinical-record categories beyond lab-result observations
 - Diagnostic report metadata export
 - Condition and allergy metadata export
 - ECG discovery/export


### PR DESCRIPTION
Refs #100.

## What changed
- Added the requested lab sections: Lipid panel, CBC, CMP / BMP, Thyroid, and Other.
- Added panel-level toggles that select or deselect every lab in each section, with per-lab toggles still available for fine-grained selection.
- Added selected vitals export: Blood Pressure, Resting Heart Rate, Heart Rate Variability (SDNN), Oxygen Saturation (SpO₂), Respiratory Rate, and Body Temperature.
- Exported blood pressure as paired systolic/diastolic CSV rows and corrected oxygen saturation output to render HealthKit fractions as percentages.
- Reworked the data-selection screen so the long metric list scrolls and the Save button stays reachable at the bottom.
- Updated HealthKit authorization, CSV generation, preview estimates, settings persistence, privacy copy, docs, and tests for the expanded metric set.

## Verification
- `xcodebuild test -project HealthExporter.xcodeproj -scheme HealthExporter -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' -derivedDataPath /private/tmp/HealthExporter-issue100-DerivedData CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- Result: 236 tests passed.

## Notes
- Clinical Records validation still needs a physical device with synced lab records.
- Vitals use HealthKit quantity samples; real-device validation is still recommended for blood-pressure pairing and source-device behavior.
