### PR TITLE
Add LOINC column and as-is disclaimer to CSV exports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,9 @@ Memory management matters because HealthKit datasets can be large:
 - Profile memory if a change could expand retained sample data.
 
 CSV format details:
-- Columns are `Date,Metric,Value,Unit,Source`
+- Every export begins with `CSVGenerator.csvDisclaimer` (three `### `-prefixed lines) followed by the column header on the next line. Use `CSVGenerator.csvPreamble` (disclaimer + header + newline) as the starting buffer.
+- Columns are `Date,Metric,LOINC,Value,Unit,Source`
+- The `LOINC` column carries the LOINC code for clinical-record lab rows and is empty for HealthKit-native metrics (weight, steps, glucose, vitals)
 - Date formats come from `DateFormatOption`
 - Sort order comes from `SortOrder`
 - Weight precision is 2 decimals

--- a/HealthExporter/HealthExporter/CSVGenerator.swift
+++ b/HealthExporter/HealthExporter/CSVGenerator.swift
@@ -40,7 +40,19 @@ struct ExportPreviewEstimate {
 
 class CSVGenerator {
 
-    static let csvHeader = "Date,Metric,Value,Unit,Source"
+    /// Three-line disclaimer prepended to every export. Each line begins with `### `
+    /// so common CSV parsers can be configured to treat them as comments.
+    static let csvDisclaimer = """
+        ### HealthExporterCSV: data exported as-is from Apple Health.
+        ### No warranty of accuracy, completeness, or fitness for any purpose.
+        ### Not a medical record. Verify with your healthcare provider before any clinical use.
+        """
+
+    static let csvHeader = "Date,Metric,LOINC,Value,Unit,Source"
+
+    /// Disclaimer block followed by a newline, then the column header and a newline.
+    /// Use this as the starting buffer for every CSV export.
+    static let csvPreamble = csvDisclaimer + "\n" + csvHeader + "\n"
 
     private static func makeDateFormatter(for option: DateFormatOption) -> DateFormatter {
         let formatter = DateFormatter()
@@ -64,20 +76,20 @@ class CSVGenerator {
         let weightKg = sample.quantity.doubleValue(for: HKUnit.gramUnit(with: .kilo))
         let (value, unitString) = convertWeight(weightKg, to: unit)
         let source = csvEscape(sample.sourceRevision.source.name)
-        return "\(date),Weight,\(String(format: "%.2f", value)),\(unitString),\(source)\n"
+        return "\(date),Weight,,\(String(format: "%.2f", value)),\(unitString),\(source)\n"
     }
 
     private static func stepsRow(for sample: HKQuantitySample, dateFormatter: DateFormatter) -> String {
         let date = dateFormatter.string(from: sample.startDate)
         let steps = sample.quantity.doubleValue(for: HKUnit.count())
         let source = csvEscape(sample.sourceRevision.source.name)
-        return "\(date),Steps,\(Int(steps)),steps,\(source)\n"
+        return "\(date),Steps,,\(Int(steps)),steps,\(source)\n"
     }
 
     private static func glucoseRow(for sample: GlucoseSampleMgDl, dateFormatter: DateFormatter) -> String {
         let date = dateFormatter.string(from: sample.startDate)
         let source = csvEscape(sample.source)
-        return "\(date),Blood Glucose,\(String(format: "%.0f", sample.value)),mg/dL,\(source)\n"
+        return "\(date),Blood Glucose,,\(String(format: "%.0f", sample.value)),mg/dL,\(source)\n"
     }
 
     private static func labResultRow(for sample: LabResultSample, dateFormatter: DateFormatter) -> String {
@@ -86,7 +98,7 @@ class CSVGenerator {
         let source = csvEscape(sample.source)
         let precision = LabMetricRegistry.metric(forLoincCode: sample.loincCode)?.valuePrecision ?? 2
         let value = String(format: "%.\(precision)f", sample.value)
-        return "\(date),\(metric),\(value),\(sample.unit),\(source)\n"
+        return "\(date),\(metric),\(sample.loincCode),\(value),\(sample.unit),\(source)\n"
     }
 
     private static func vitalRow(for sample: HKQuantitySample, component: VitalMetricComponent, temperatureUnit: TemperatureUnit, dateFormatter: DateFormatter) -> String {
@@ -94,7 +106,7 @@ class CSVGenerator {
         let source = csvEscape(sample.sourceRevision.source.name)
         let result = component.valueAndUnit(from: sample.quantity, temperatureUnit: temperatureUnit)
         let value = String(format: "%.\(component.valuePrecision)f", result.value)
-        return "\(date),\(component.displayName),\(value),\(result.unit),\(source)\n"
+        return "\(date),\(component.displayName),,\(value),\(result.unit),\(source)\n"
     }
 
     // MARK: - Append methods (memory-efficient, sort in-place, write directly to string)
@@ -152,7 +164,7 @@ class CSVGenerator {
         let rowCount = weightCount + stepsCount + glucoseCount + labCount + vitalCount
 
         let dateFormatter = makeDateFormatter(for: dateFormat)
-        var estimatedByteCount = (csvHeader + "\n").utf8.count
+        var estimatedByteCount = csvPreamble.utf8.count
 
         if let samples = weightSamples {
             for sample in samples {
@@ -193,21 +205,21 @@ class CSVGenerator {
     // MARK: - Legacy convenience methods (used by tests and single-metric exports)
 
     static func generateWeightCSV(from samples: [HKQuantitySample], unit: WeightUnit, dateFormat: DateFormatOption = .yyyyMMddHHmmss, sortOrder: SortOrder = .ascending) -> String {
-        var csv = csvHeader + "\n"
+        var csv = csvPreamble
         var mutableSamples = samples
         appendWeightRows(to: &csv, samples: &mutableSamples, unit: unit, dateFormat: dateFormat, sortOrder: sortOrder)
         return csv
     }
 
     static func generateStepsCSV(from samples: [HKQuantitySample], dateFormat: DateFormatOption = .yyyyMMddHHmmss, sortOrder: SortOrder = .ascending) -> String {
-        var csv = csvHeader + "\n"
+        var csv = csvPreamble
         var mutableSamples = samples
         appendStepsRows(to: &csv, samples: &mutableSamples, dateFormat: dateFormat, sortOrder: sortOrder)
         return csv
     }
 
     static func generateCombinedCSV(weightSamples: [HKQuantitySample]?, stepsSamples: [HKQuantitySample]?, glucoseSamples: [GlucoseSampleMgDl]?, labResults: [LabResultSample]?, vitalSamples: [VitalMetricComponent: [HKQuantitySample]]? = nil, weightUnit: WeightUnit, temperatureUnit: TemperatureUnit = .fahrenheit, dateFormat: DateFormatOption = .yyyyMMddHHmmss, sortOrder: SortOrder = .ascending) -> String {
-        var csv = csvHeader + "\n"
+        var csv = csvPreamble
 
         if var samples = weightSamples {
             appendWeightRows(to: &csv, samples: &samples, unit: weightUnit, dateFormat: dateFormat, sortOrder: sortOrder)

--- a/HealthExporter/HealthExporter/DataSelectionView.swift
+++ b/HealthExporter/HealthExporter/DataSelectionView.swift
@@ -697,7 +697,7 @@ struct DataSelectionView: View {
         let sortOrder = settings.sortOrder
         let weightUnit = settings.weightUnit
         let temperatureUnit = settings.temperatureUnit
-        var csv = CSVGenerator.csvHeader + "\n"
+        var csv = CSVGenerator.csvPreamble
 
         if var samples = payload.weightSamples {
             payload.weightSamples = nil

--- a/HealthExporterTests/A1CCSVBytePinningTests.swift
+++ b/HealthExporterTests/A1CCSVBytePinningTests.swift
@@ -38,9 +38,8 @@ final class A1CCSVBytePinningTests: XCTestCase {
 
     func testA1CRow_exactByteFormat_percentUnit() {
         let sample = a1cSample(date: fixedDate, value: 7.2, unit: "%", source: "TestClinic")
-        let expected = """
-        Date,Metric,Value,Unit,Source
-        2024-06-15T10:30:00Z,Hemoglobin A1C,7.20,%,TestClinic
+        let expected = CSVGenerator.csvPreamble + """
+        2024-06-15T10:30:00Z,Hemoglobin A1C,4548-4,7.20,%,TestClinic
 
         """
         XCTAssertEqual(generateCSV(for: [sample]), expected)
@@ -48,9 +47,8 @@ final class A1CCSVBytePinningTests: XCTestCase {
 
     func testA1CRow_exactByteFormat_mmolPerMolUnit() {
         let sample = a1cSample(date: fixedDate, value: 55.0, unit: "mmol/mol", source: "LabCorp")
-        let expected = """
-        Date,Metric,Value,Unit,Source
-        2024-06-15T10:30:00Z,Hemoglobin A1C,55.00,mmol/mol,LabCorp
+        let expected = CSVGenerator.csvPreamble + """
+        2024-06-15T10:30:00Z,Hemoglobin A1C,4548-4,55.00,mmol/mol,LabCorp
 
         """
         XCTAssertEqual(generateCSV(for: [sample]), expected)
@@ -58,9 +56,8 @@ final class A1CCSVBytePinningTests: XCTestCase {
 
     func testA1CRow_exactByteFormat_sourceWithCommaIsCSVEscaped() {
         let sample = a1cSample(date: fixedDate, value: 6.1, unit: "%", source: "Foo, Inc.")
-        let expected = """
-        Date,Metric,Value,Unit,Source
-        2024-06-15T10:30:00Z,Hemoglobin A1C,6.10,%,"Foo, Inc."
+        let expected = CSVGenerator.csvPreamble + """
+        2024-06-15T10:30:00Z,Hemoglobin A1C,4548-4,6.10,%,"Foo, Inc."
 
         """
         XCTAssertEqual(generateCSV(for: [sample]), expected)
@@ -68,9 +65,8 @@ final class A1CCSVBytePinningTests: XCTestCase {
 
     func testA1CRow_exactByteFormat_sourceWithQuoteIsCSVEscaped() {
         let sample = a1cSample(date: fixedDate, value: 6.1, unit: "%", source: "Mom's Lab")
-        let expected = """
-        Date,Metric,Value,Unit,Source
-        2024-06-15T10:30:00Z,Hemoglobin A1C,6.10,%,Mom's Lab
+        let expected = CSVGenerator.csvPreamble + """
+        2024-06-15T10:30:00Z,Hemoglobin A1C,4548-4,6.10,%,Mom's Lab
 
         """
         XCTAssertEqual(generateCSV(for: [sample]), expected)
@@ -91,10 +87,9 @@ final class A1CCSVBytePinningTests: XCTestCase {
             a1cSample(date: newer, value: 7.5, unit: "%", source: "C"),
             a1cSample(date: older, value: 6.5, unit: "%", source: "C"),
         ]
-        let expected = """
-        Date,Metric,Value,Unit,Source
-        2024-01-01T00:00:00Z,Hemoglobin A1C,6.50,%,C
-        2024-12-31T23:59:59Z,Hemoglobin A1C,7.50,%,C
+        let expected = CSVGenerator.csvPreamble + """
+        2024-01-01T00:00:00Z,Hemoglobin A1C,4548-4,6.50,%,C
+        2024-12-31T23:59:59Z,Hemoglobin A1C,4548-4,7.50,%,C
 
         """
         XCTAssertEqual(generateCSV(for: samples), expected)

--- a/HealthExporterTests/CSVGeneratorTests.swift
+++ b/HealthExporterTests/CSVGeneratorTests.swift
@@ -13,6 +13,15 @@ final class CSVGeneratorTests: XCTestCase {
     private let bodyTemperatureType = HKQuantityType.quantityType(forIdentifier: .bodyTemperature)!
     private let mgDlUnit = HKUnit.gramUnit(with: .milli).unitDivided(by: HKUnit.literUnit(with: .deci))
 
+    /// Returns just the data rows of a CSV (disclaimer and column header lines stripped).
+    /// Tests previously indexed by `lines[1]` assumed only a single header line preceded
+    /// the data; now there are also three `### ` disclaimer lines.
+    private func dataRows(in csv: String) -> [String] {
+        csv.components(separatedBy: "\n").filter { line in
+            !line.isEmpty && !line.hasPrefix("###") && !line.hasPrefix("Date,")
+        }
+    }
+
     /// A fixed reference date (2024-01-15 09:30:00 UTC) for deterministic test output.
     private var referenceDate: Date {
         var components = DateComponents()
@@ -30,12 +39,18 @@ final class CSVGeneratorTests: XCTestCase {
 
     func testGenerateWeightCSV_emptyInput_returnsHeaderOnly() {
         let csv = CSVGenerator.generateWeightCSV(from: [], unit: .kilograms)
-        XCTAssertEqual(csv, "Date,Metric,Value,Unit,Source\n")
+        XCTAssertEqual(csv, CSVGenerator.csvPreamble)
     }
 
     func testGenerateWeightCSV_hasCorrectHeader() {
         let csv = CSVGenerator.generateWeightCSV(from: [], unit: .kilograms)
-        XCTAssertTrue(csv.hasPrefix("Date,Metric,Value,Unit,Source"))
+        XCTAssertTrue(csv.contains("Date,Metric,LOINC,Value,Unit,Source"))
+    }
+
+    func testGenerateWeightCSV_emitsDisclaimerBeforeHeader() {
+        let csv = CSVGenerator.generateWeightCSV(from: [], unit: .kilograms)
+        XCTAssertTrue(csv.hasPrefix("### "), "CSV should begin with a `### ` disclaimer line")
+        XCTAssertTrue(csv.contains("Not a medical record"), "Disclaimer should mention the file is not a medical record")
     }
 
     func testGenerateWeightCSV_kilograms_formatsCorrectly() {
@@ -46,11 +61,11 @@ final class CSVGeneratorTests: XCTestCase {
             end: referenceDate
         )
         let csv = CSVGenerator.generateWeightCSV(from: [sample], unit: .kilograms)
-        let lines = csv.components(separatedBy: "\n").filter { !$0.isEmpty }
-        XCTAssertEqual(lines.count, 2)
-        XCTAssertTrue(lines[1].contains(",Weight,"))
-        XCTAssertTrue(lines[1].contains(",75.00,"))
-        XCTAssertTrue(lines[1].contains(",kg,"))
+        let rows = dataRows(in: csv)
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertTrue(rows[0].contains(",Weight,"))
+        XCTAssertTrue(rows[0].contains(",75.00,"))
+        XCTAssertTrue(rows[0].contains(",kg,"))
     }
 
     func testGenerateWeightCSV_pounds_convertsFromKg() {
@@ -91,8 +106,7 @@ final class CSVGeneratorTests: XCTestCase {
             )
         }
         let csv = CSVGenerator.generateWeightCSV(from: samples, unit: .kilograms)
-        let lines = csv.components(separatedBy: "\n").filter { !$0.isEmpty }
-        XCTAssertEqual(lines.count, 6) // 1 header + 5 data rows
+        XCTAssertEqual(dataRows(in: csv).count, 5)
     }
 
     func testGenerateWeightCSV_iso8601Format_usesUTC() {
@@ -111,7 +125,7 @@ final class CSVGeneratorTests: XCTestCase {
 
     func testGenerateStepsCSV_emptyInput_returnsHeaderOnly() {
         let csv = CSVGenerator.generateStepsCSV(from: [])
-        XCTAssertEqual(csv, "Date,Metric,Value,Unit,Source\n")
+        XCTAssertEqual(csv, CSVGenerator.csvPreamble)
     }
 
     func testGenerateStepsCSV_formatsCorrectly() {
@@ -149,7 +163,7 @@ final class CSVGeneratorTests: XCTestCase {
             labResults: nil,
             weightUnit: .kilograms
         )
-        XCTAssertEqual(csv, "Date,Metric,Value,Unit,Source\n")
+        XCTAssertEqual(csv, CSVGenerator.csvPreamble)
     }
 
     func testGenerateCombinedCSV_allEmpty_returnsHeaderOnly() {
@@ -160,7 +174,7 @@ final class CSVGeneratorTests: XCTestCase {
             labResults: [],
             weightUnit: .kilograms
         )
-        XCTAssertEqual(csv, "Date,Metric,Value,Unit,Source\n")
+        XCTAssertEqual(csv, CSVGenerator.csvPreamble)
     }
 
     func testGenerateCombinedCSV_weightOnly_containsWeightRow() {
@@ -177,9 +191,9 @@ final class CSVGeneratorTests: XCTestCase {
             labResults: nil,
             weightUnit: .kilograms
         )
-        let lines = csv.components(separatedBy: "\n").filter { !$0.isEmpty }
-        XCTAssertEqual(lines.count, 2)
-        XCTAssertTrue(lines[1].contains(",Weight,"))
+        let rows = dataRows(in: csv)
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertTrue(rows[0].contains(",Weight,"))
     }
 
     func testGenerateCombinedCSV_stepsOnly_containsStepsRow() {
@@ -249,8 +263,7 @@ final class CSVGeneratorTests: XCTestCase {
             labResults: nil,
             weightUnit: .kilograms
         )
-        let lines = csv.components(separatedBy: "\n").filter { !$0.isEmpty }
-        XCTAssertEqual(lines.count, 4) // header + 3 data rows
+        XCTAssertEqual(dataRows(in: csv).count, 3)
         XCTAssertTrue(csv.contains(",Weight,"))
         XCTAssertTrue(csv.contains(",Steps,"))
         XCTAssertTrue(csv.contains(",Blood Glucose,"))
@@ -282,10 +295,9 @@ final class CSVGeneratorTests: XCTestCase {
             weightUnit: .kilograms
         )
 
-        let lines = csv.components(separatedBy: "\n").filter { !$0.isEmpty }
-        XCTAssertEqual(lines.count, 3)
-        XCTAssertTrue(csv.contains(",Blood Pressure Systolic,120,mmHg,"))
-        XCTAssertTrue(csv.contains(",Blood Pressure Diastolic,80,mmHg,"))
+        XCTAssertEqual(dataRows(in: csv).count, 2)
+        XCTAssertTrue(csv.contains(",Blood Pressure Systolic,,120,mmHg,"))
+        XCTAssertTrue(csv.contains(",Blood Pressure Diastolic,,80,mmHg,"))
     }
 
     func testGenerateCombinedCSV_oxygenSaturation_formatsPercent() {
@@ -305,7 +317,7 @@ final class CSVGeneratorTests: XCTestCase {
             weightUnit: .kilograms
         )
 
-        XCTAssertTrue(csv.contains(",Oxygen Saturation,98.5,%,"))
+        XCTAssertTrue(csv.contains(",Oxygen Saturation,,98.5,%,"))
     }
 
     func testGenerateCombinedCSV_bodyTemperature_usesSelectedUnit() {
@@ -326,7 +338,7 @@ final class CSVGeneratorTests: XCTestCase {
             temperatureUnit: .fahrenheit
         )
 
-        XCTAssertTrue(csv.contains(",Body Temperature,98.6,°F,"))
+        XCTAssertTrue(csv.contains(",Body Temperature,,98.6,°F,"))
     }
 
     func testGenerateCombinedCSV_a1cData_containsA1CRow() {
@@ -434,7 +446,7 @@ final class CSVGeneratorTests: XCTestCase {
             labResults: [sample],
             weightUnit: .kilograms
         )
-        XCTAssertTrue(csv.contains(",Total Cholesterol,202,mg/dL,"))
+        XCTAssertTrue(csv.contains(",Total Cholesterol,2093-3,202,mg/dL,"))
     }
 
     func testLabResultRow_unknownLoinc_defaultsToTwoDecimals() {
@@ -454,8 +466,73 @@ final class CSVGeneratorTests: XCTestCase {
             labResults: [sample],
             weightUnit: .kilograms
         )
-        XCTAssertTrue(csv.contains(",Mystery Lab,3.46,u,"))
+        XCTAssertTrue(csv.contains(",Mystery Lab,0000-0,3.46,u,"))
     }
+
+    // MARK: - LOINC column
+
+    func testLOINCColumn_emptyForWeightSteps() {
+        let weightSample = HKQuantitySample(
+            type: weightType,
+            quantity: HKQuantity(unit: .gramUnit(with: .kilo), doubleValue: 75.0),
+            start: referenceDate,
+            end: referenceDate
+        )
+        let stepsSample = HKQuantitySample(
+            type: stepsType,
+            quantity: HKQuantity(unit: .count(), doubleValue: 8000),
+            start: referenceDate,
+            end: referenceDate
+        )
+        let csv = CSVGenerator.generateCombinedCSV(
+            weightSamples: [weightSample],
+            stepsSamples: [stepsSample],
+            glucoseSamples: nil,
+            labResults: nil,
+            weightUnit: .kilograms
+        )
+        XCTAssertTrue(csv.contains(",Weight,,75.00,kg,"), "Weight row should have empty LOINC column")
+        XCTAssertTrue(csv.contains(",Steps,,8000,steps,"), "Steps row should have empty LOINC column")
+    }
+
+    func testLOINCColumn_emptyForVitalRows() {
+        let sample = HKQuantitySample(
+            type: oxygenType,
+            quantity: HKQuantity(unit: .percent(), doubleValue: 0.97),
+            start: referenceDate,
+            end: referenceDate
+        )
+        let csv = CSVGenerator.generateCombinedCSV(
+            weightSamples: nil,
+            stepsSamples: nil,
+            glucoseSamples: nil,
+            labResults: nil,
+            vitalSamples: [.oxygenSaturation: [sample]],
+            weightUnit: .kilograms
+        )
+        XCTAssertTrue(csv.contains(",Oxygen Saturation,,97.0,%,"), "Vital row should have empty LOINC column")
+    }
+
+    func testLOINCColumn_populatedForLabRows() {
+        let sample = LabResultSample(
+            metricName: "Hemoglobin A1C",
+            loincCode: LOINCCode.hemoglobinA1C,
+            effectiveDateTime: referenceDate,
+            value: 5.6,
+            unit: "%",
+            source: "Lab"
+        )
+        let csv = CSVGenerator.generateCombinedCSV(
+            weightSamples: nil,
+            stepsSamples: nil,
+            glucoseSamples: nil,
+            labResults: [sample],
+            weightUnit: .kilograms
+        )
+        XCTAssertTrue(csv.contains(",Hemoglobin A1C,4548-4,5.60,%,"), "Lab row should include LOINC code from sample")
+    }
+
+    // MARK: - CSV escaping (labs)
 
     func testLabResultRow_metricNameContainingCommaIsCSVEscaped() {
         let sample = LabResultSample(
@@ -522,7 +599,7 @@ final class CSVGeneratorTests: XCTestCase {
             labResults: nil,
             weightUnit: .kilograms
         )
-        XCTAssertTrue(csv.hasPrefix("Date,Metric,"), "Should have single Date column, not Date,ISO8601")
+        XCTAssertTrue(csv.contains("Date,Metric,LOINC,Value,Unit,Source"), "Should have single Date column, not Date,ISO8601")
         XCTAssertFalse(csv.contains("ISO8601"), "Should not have separate ISO8601 column")
     }
 
@@ -553,9 +630,9 @@ final class CSVGeneratorTests: XCTestCase {
             weightUnit: .kilograms,
             sortOrder: .ascending
         )
-        let linesAsc = csvAsc.components(separatedBy: "\n").filter { !$0.isEmpty }
-        XCTAssertTrue(linesAsc[1].contains("70.00"), "Ascending: older (70kg) should come first")
-        XCTAssertTrue(linesAsc[2].contains("80.00"), "Ascending: newer (80kg) should come second")
+        let rowsAsc = dataRows(in: csvAsc)
+        XCTAssertTrue(rowsAsc[0].contains("70.00"), "Ascending: older (70kg) should come first")
+        XCTAssertTrue(rowsAsc[1].contains("80.00"), "Ascending: newer (80kg) should come second")
 
         let csvDesc = CSVGenerator.generateCombinedCSV(
             weightSamples: [sample1, sample2],
@@ -565,8 +642,8 @@ final class CSVGeneratorTests: XCTestCase {
             weightUnit: .kilograms,
             sortOrder: .descending
         )
-        let linesDesc = csvDesc.components(separatedBy: "\n").filter { !$0.isEmpty }
-        XCTAssertTrue(linesDesc[1].contains("80.00"), "Descending: newer (80kg) should come first")
-        XCTAssertTrue(linesDesc[2].contains("70.00"), "Descending: older (70kg) should come second")
+        let rowsDesc = dataRows(in: csvDesc)
+        XCTAssertTrue(rowsDesc[0].contains("80.00"), "Descending: newer (80kg) should come first")
+        XCTAssertTrue(rowsDesc[1].contains("70.00"), "Descending: older (70kg) should come second")
     }
 }

--- a/README.md
+++ b/README.md
@@ -75,16 +75,21 @@ The exported CSV includes the following columns:
 
 Example:
 ```
-Date,Metric,Value,Unit,Source
-2026-01-09 10:30:00,Weight,185.50,lbs,Withings
-2026-01-09 11:00:00,Steps,5432,steps,Apple Watch
-2026-01-09 14:30:00,Blood Glucose,145,mg/dL,MyFitnessPal
-2026-01-15 14:30:00,Hemoglobin A1C,7.50,%,Apple Health
-2026-01-15 14:31:00,Total Cholesterol,184,mg/dL,Apple Health
-2026-01-15 14:32:00,Blood Pressure Systolic,120,mmHg,Apple Health
-2026-01-15 14:32:00,Blood Pressure Diastolic,80,mmHg,Apple Health
-2026-01-15 14:33:00,Oxygen Saturation,98.5,%,Apple Health
+### HealthExporterCSV: data exported as-is from Apple Health.
+### No warranty of accuracy, completeness, or fitness for any purpose.
+### Not a medical record. Verify with your healthcare provider before any clinical use.
+Date,Metric,LOINC,Value,Unit,Source
+2026-01-09 10:30:00,Weight,,185.50,lbs,Withings
+2026-01-09 11:00:00,Steps,,5432,steps,Apple Watch
+2026-01-09 14:30:00,Blood Glucose,,145,mg/dL,MyFitnessPal
+2026-01-15 14:30:00,Hemoglobin A1C,4548-4,7.50,%,Apple Health
+2026-01-15 14:31:00,Total Cholesterol,2093-3,184,mg/dL,Apple Health
+2026-01-15 14:32:00,Blood Pressure Systolic,,120,mmHg,Apple Health
+2026-01-15 14:32:00,Blood Pressure Diastolic,,80,mmHg,Apple Health
+2026-01-15 14:33:00,Oxygen Saturation,,98.5,%,Apple Health
 ```
+
+Each export starts with three `### `-prefixed disclaimer lines so common CSV parsers can be configured to skip them as comments. The `LOINC` column carries the LOINC code for clinical-record lab results and is left empty for HealthKit-native metrics (weight, steps, glucose, vitals).
 
 Data can be sorted ascending (oldest first) or descending (newest first) within each metric type. Filename format: `HealthExporter_YYYY-MM-DD_HHMMSS.csv`.
 

--- a/docs/a1c/QUICK_REFERENCE.md
+++ b/docs/a1c/QUICK_REFERENCE.md
@@ -47,9 +47,12 @@ Also make sure the target has HealthKit and Clinical Health Records capabilities
 ## CSV Example
 
 ```csv
-Date,Metric,Value,Unit,Source
-2026-01-15 14:30:00,Hemoglobin A1C,7.50,%,Apple Health
-2026-01-15 14:31:00,Total Cholesterol,184,mg/dL,Apple Health
+### HealthExporterCSV: data exported as-is from Apple Health.
+### No warranty of accuracy, completeness, or fitness for any purpose.
+### Not a medical record. Verify with your healthcare provider before any clinical use.
+Date,Metric,LOINC,Value,Unit,Source
+2026-01-15 14:30:00,Hemoglobin A1C,4548-4,7.50,%,Apple Health
+2026-01-15 14:31:00,Total Cholesterol,2093-3,184,mg/dL,Apple Health
 ```
 
 ## Adding a New Lab


### PR DESCRIPTION
## Summary
- Adds a `LOINC` column to the CSV export, between `Metric` and `Value`. Lab rows populate it with the LOINC code already on `LabResultSample`; built-in metrics (weight, steps, glucose) and vitals leave it empty since the column is scoped to clinical-record lab data for now.
- Prepends every export with a three-line `### `-prefixed disclaimer ("data as-is", "no warranty", "not a medical record") so it shows up at the top of the file in any text editor while still being skippable by CSV parsers configured to ignore `#`-prefixed lines.
- Centralizes the new preamble as `CSVGenerator.csvDisclaimer` / `CSVGenerator.csvPreamble` and routes the manual CSV assembly in `DataSelectionView.continuePendingExport` through it.

## Example output

```
### HealthExporterCSV: data exported as-is from Apple Health.
### No warranty of accuracy, completeness, or fitness for any purpose.
### Not a medical record. Verify with your healthcare provider before any clinical use.
Date,Metric,LOINC,Value,Unit,Source
2026-01-09 10:30:00,Weight,,185.50,lbs,Withings
2026-01-15 14:30:00,Hemoglobin A1C,4548-4,7.50,%,Apple Health
2026-01-15 14:31:00,Total Cholesterol,2093-3,184,mg/dL,Apple Health
2026-01-15 14:32:00,Blood Pressure Systolic,,120,mmHg,Apple Health
```

## Verification
- `xcodebuild test -project HealthExporter.xcodeproj -scheme HealthExporter -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- 240 tests passing (was 236 + 4 new LOINC-column tests).
- `makePreviewEstimate` continues to match `csv.utf8.count` after the preamble change (existing `ExportPreviewEstimateTests.testMakePreviewEstimate_matchesGeneratedCSVByteCount` covers this without modification).

## Test plan
- [ ] Open the app on a physical device, run an export that includes at least one lab and one built-in/vital metric, and confirm the resulting CSV begins with three `### ` lines, has the new `LOINC` column header, and shows the LOINC code for the lab row with an empty column for the built-in/vital rows.
- [ ] Open the file in Numbers / Excel and confirm the disclaimer lines render in the first column without disrupting the data grid.
